### PR TITLE
Support retrying a resource if running the resource or acquiring the lock fails

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,10 +7,13 @@ provisioner:
 
 platforms:
   - name: ubuntu-14.04
-    driver:
-      require_chef_omnibus: 12.13.37
     run_list:
     attributes: {
+      locking_resource: {
+        restart_lock_acquire: {
+          timeout: 3
+        }
+      }
     }
 suites:
   - name: simple_locking_resource
@@ -25,3 +28,9 @@ suites:
   - name: serialized_process
     run_list:
       - 'recipe[locking_resource_test::serialized_process_lock_handling]'
+  - name: re_run_lock_older
+    run_list:
+      - 'recipe[locking_resource_test::re_run_lock_older]'
+  - name: re_run_lock_newer
+    run_list:
+      - 'recipe[locking_resource_test::re_run_lock_newer]'

--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,9 @@ ruby RUBY_VERSION
 gem 'zookeeper'
 gem 'poise'
 group :test do
-  gem 'rack', '< 2'
+  gem 'rack'
   gem 'simplecov'
   gem 'chefspec'
   gem 'berkshelf'
-  gem 'buff-extensions', '~> 1.0'
+  gem 'buff-extensions'
 end

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Contributing
 ============
 Contributions are welcomed! This cookbook tries to have rigorous testing to verify that locks are held and released as expected. The current process for kicking these off on a machine with ChefDK is:
 ````
-$ bundler --path=vendor/cache
+$ export PATH=/opt/chefdk/embedded/bin:$PATH
+$ bundler package --path=vendor/cache
 $ berks vendor
 $ bundler exec rspec
 $ kitchen converge '.*'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,14 +5,16 @@
 #############################################
 # The path in ZK where the restart locks (znodes)  need to be created
 # The path should exist in ZooKeeper e.g. '/lock'
-default[:locking_resource][:restart_lock][:root] = '/lock'
+default['locking_resource']['restart_lock']['root'] = '/lock'
+# Where we store failed lock attempts to run in a future Chef run
+default['locking_resource']['failed_locks'] = {}
 # Sleep time in seconds between tries to acquire the lock for restart
-default[:locking_resource][:restart_lock_acquire][:sleep_time] = 0.25
+default['locking_resource']['restart_lock_acquire']['sleep_time'] = 0.25
 # Timeout in seconds before failing to acquire lock
-default[:locking_resource][:restart_lock_acquire][:timeout] = 30
+default['locking_resource']['restart_lock_acquire']['timeout'] = 30
 # Flag to control whether automatic restarts due to config changes need to be
 # skipped for e.g. if ZK quorum is down or if the recipes need to be run in a
 # non ZK env
-default[:locking_resource][:skip_restart_coordination] = false
+default['locking_resource']['skip_restart_coordination'] = false
 # The default zookeeper quorum
-default[:locking_resource][:zookeeper_servers] = ['localhost:2181']
+default['locking_resource']['zookeeper_servers'] = ['localhost:2181']

--- a/libraries/locking_resource.rb
+++ b/libraries/locking_resource.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: locking_resource
 # Library:: locking_resource
 #
-# Copyright (C) 2016 Bloomberg Finance L.P.
+# Copyright (C) 2017 Bloomberg Finance L.P.
 #
 require 'poise'
 require 'set'
@@ -16,13 +16,17 @@ class Chef
     default_action(:serialize)
 
     attribute(:name, kind_of: String)
+    attribute(:lock_name, kind_of: String, default: nil)
     attribute(:resource, kind_of: String, required: true)
     attribute(:perform, kind_of: Symbol, required: true)
-    attribute(:timeout, kind_of: Integer, default: lazy { node[:locking_resource][:restart_lock_acquire][:timeout] })
+    attribute(:timeout, kind_of: Integer, default: \
+      lazy { node['locking_resource']['restart_lock_acquire']['timeout'] })
+    attribute(:zookeeper_hosts, kind_of: Array, default: \
+      lazy { node['locking_resource']['zookeeper_servers'] })
     attribute(:process_pattern, option_collector: true)
-    attribute(:lock_data, kind_of: String, default: lazy { node[:fqdn] })
+    attribute(:lock_data, kind_of: String, default: lazy { node['fqdn'] })
 
-    # XXX should validate node[:locking_resource][:zookeeper_servers] parses
+    # XXX should validate node['locking_resource']['zookeeper_servers'] parses
   end
 
   class Provider::LockingResource < Provider
@@ -31,99 +35,170 @@ class Chef
     include ::LockingResource::Helper
     provides(:locking_resource)
 
+    #
+    # Loops trying to acquire lock and returns true if lock acquired,
+    # false otherwise
+    # Inputs:
+    #   zk_hosts   - a string of <host>:<port>,<host>:<port>,... for ZK hosts
+    #   lock_path  - the path for the lock
+    #   lock_data  - the data to record in the lock, if we acquire the lock
+    #   timeout    - the overall time to try acquiring the lock
+    #   retry_time - the time to re-try acquiring the lock (should be less
+    #                than and a multiple of the total timeout)
+    def acquire_lock(zk_hosts, lock_path, lock_data, timeout, retry_time)
+      Chef::Log.info "Acquiring lock #{lock_path}"
+      # acquire lock
+      # rubocop:disable no-and-or-or
+      got_lock = lock_matches?(zk_hosts, lock_path, lock_data)\
+        and Chef::Log.info 'Found stale lock'
+      # rubocop:enable no-and-or-or
+
+      # intentionally do not use a timeout to avoid leaving a wonky
+      # zookeeper object or connection if we interrupt it -- thus we trust
+      # the zookeeper object to not wantonly hang
+      start_time = Time.now
+      while !got_lock && (start_time + timeout) >= Time.now
+        # rubocop:disable no-and-or-or
+        got_lock = create_node(zk_hosts, lock_path, lock_data)\
+          and Chef::Log.info 'Acquired new lock'
+        # rubocop:enable no-and-or-or
+        sleep(retry_time)
+        Chef::Log.warn "Sleeping for lock #{lock_path}"
+      end
+      # see if we ever got a lock -- if not record it for later
+      if !got_lock
+        Chef::Log.warn "Did not get lock #{lock_path}"
+      end
+      got_lock
+    end
+
+    #
+    # Used to action a resource with locking semantics
     def action_serialize
-      converge_by("serializing #{new_resource.name} via lock") do
+      converge_by("serializing #{new_resource.name}") do
         r = run_context.resource_collection.resources(new_resource.resource)
+        fail "Unable to find resource #{new_resource.resource} in " \
+             'resources' unless r
 
         # to avoid namespace collisions replace spaces in resource name with
         # a colon -- zookeeper's quite permissive on paths:
         # https://zookeeper.apache.org/doc/trunk/zookeeperProgrammers.html#ch_zkDataModel
-        lock_path = ::File.join(node[:locking_resource][:restart_lock][:root],
-                              new_resource.name.gsub(' ', ':'))
+        lock_name = new_resource.lock_name || new_resource.name.tr_s(' ', ':')
+        lock_path = ::File.join(
+          node['locking_resource']['restart_lock']['root'],
+          lock_name
+        )
 
-        unless node[:locking_resource][:skip_restart_coordination]
-          zk_hosts = parse_zk_hosts(node[:locking_resource][:zookeeper_servers])
-
-          Chef::Log.info "Acquiring lock #{lock_path}"
-          # acquire lock
-          got_lock = lock_matches?(zk_hosts, lock_path, new_resource.lock_data) and \
-            Chef::Log.info "Found stale lock"
-          # intentionally do not use a timeout to avoid leaving a wonky zookeeper
-          # object or connection if we interrupt it -- thus we trust the
-          # zookeeper object to not wantonly hang
-          start_time = Time.now
-          while !got_lock && (start_time + new_resource.timeout) >= Time.now
-            got_lock = create_node(zk_hosts, lock_path, new_resource.lock_data) and \
-              Chef::Log.info 'Acquired new lock'
-            sleep(node[:locking_resource][:restart_lock_acquire][:sleep_time])
-          end
-        else
+        zk_hosts = parse_zk_hosts(new_resource.zookeeper_hosts)
+        if node['locking_resource']['skip_restart_coordination']
+          got_lock = false
           Chef::Log.warn 'Restart coordination disabled -- skipping lock ' \
                          "acquisition on #{lock_path}"
+        else
+          loop_time = \
+            node['locking_resource']['restart_lock_acquire']['sleep_time']
+          got_lock = acquire_lock(zk_hosts, lock_path, new_resource.lock_data,
+                                  new_resource.timeout, loop_time)
         end
 
         # affect the resource, if we got the lock -- or error
-        if got_lock or node[:locking_resource][:skip_restart_coordination]
+        if got_lock || node['locking_resource']['skip_restart_coordination']
           notifying_block do
             r.run_action new_resource.perform
             r.resolve_notification_references
             new_resource.updated_by_last_action(r.updated)
-            release_lock(zk_hosts, lock_path, new_resource.lock_data)
+            begin
+              release_lock(zk_hosts, lock_path, new_resource.lock_data)
+            rescue ::LockingResource::Helper::LockingResourceException => e
+              Chef::Log.warn e.message
+            end
           end
         else
-          raise 'Failed to acquire lock for ' +
+          need_rerun(node, lock_path)
+          fail 'Failed to acquire lock for ' \
                 "LockingResource[#{new_resource.name}], path #{lock_path}"
         end
       end
     end
 
     # Only restart the service if we are holding the lock
-    # and the service has not restarted since we got the lock
+    # and the service has not restarted since we started trying to get the lock
     def action_serialize_process
       vppo = ::LockingResource::Helper::VALID_PROCESS_PATTERN_OPTS
-      raise "Need a process pattern attribute" unless \
-        new_resource.process_pattern.length != 0
-      raise "Only expect options: #{vppo.keys} but got " \
-        "#{new_resource.process_pattern.keys}" if \
-        Set.new(new_resource.process_pattern.keys) < \
+      raise 'Need a process pattern attribute' unless \
+        !new_resource.process_pattern.empty?
+      if Set.new(new_resource.process_pattern.keys) < \
         Set.new(vppo.keys)
-      converge_by("serializing as process #{new_resource.name} via lock") do
+        raise "Only expect options: #{vppo.keys} but got " \
+          "#{new_resource.process_pattern.keys}"
+      end
+      converge_by("serializing #{new_resource.name} on process") do
+        l_time = false
+        lock_and_rerun = false
+
         r = run_context.resource_collection.resources(new_resource.resource)
+        zk_hosts = parse_zk_hosts(new_resource.zookeeper_hosts)
+
         # convert keys from strings to symbols for process_start_time()
-        start_time_args = new_resource.process_pattern.inject({}) do |memo,(k,v)|
+        start_time_arg = \
+            new_resource.process_pattern.inject({}) do |memo, (k, v)|
           memo[k.to_sym] = v
           memo
         end
-        p_start = process_start_time(start_time_args)
 
-        # if the process is not running we do not care about lock management --
-        # just run the action
+        p_start = process_start_time(start_time_arg) || false
+
+        # questionable if we want to include cookbook_name and recipe_name in
+        # the lock as we may have multiple resources with the same name
+        lock_name = new_resource.lock_name || new_resource.name.tr_s(' ', ':')
+        lock_path = ::File.join(
+          node['locking_resource']['restart_lock']['root'],
+          lock_name
+        )
+
+        r_time = rerun_time?(node, lock_path)
+        begin
+          got_lock = lock_matches?(zk_hosts, lock_path, new_resource.lock_data)
+          l_time = get_node_ctime(zk_hosts, lock_path) if got_lock
+        rescue ::LockingResource::Helper::LockingResourceException => e
+          Chef::Log.warn e.message
+        end
+        Chef::Log.warn 'Found stale lock' if got_lock
+
+        # if process is started see if we need to restart it again
         if p_start
-          lock_path = ::File.join(node[:locking_resource][:restart_lock][:root],
-                                  new_resource.name.gsub(' ', ':'))
-          zk_hosts = parse_zk_hosts(node[:locking_resource][:zookeeper_servers])
-
-          got_lock = lock_matches?(zk_hosts, lock_path, new_resource.lock_data) or return
-          l_time = get_node_ctime(zk_hosts, lock_path)
-          Chef::Log.warn "Found stale lock" if got_lock
+          node_rerun_needed = p_start <= (r_time || Time.new(0))
+          lock_rerun_needed = p_start <= (l_time || Time.new(0))
+          lock_and_rerun = node_rerun_needed || lock_rerun_needed
         end
 
-        if !p_start or p_start <= l_time
-          Chef::Log.warn "Restarting process: lock time " \
-                         "#{l_time}; process restarted #{p_start}"
+        # if we are not running the process -- run! Otherwise if we have a
+        # past, failed restart attempt, re-run
+        if !p_start || lock_and_rerun
+          Chef::Log.info 'Restarting process: lock time: ' \
+                         "#{l_time}; rerun flag time: #{r_time}; " \
+                         "process restarted since lock: #{p_start}"
           notifying_block do
             r.run_action new_resource.perform
             r.resolve_notification_references
             new_resource.updated_by_last_action(r.updated)
           end
         else
-          Chef::Log.warn "Not restarting process: lock time " \
-                         "#{l_time}; process restarted #{p_start}"
+          Chef::Log.info "Not restarting process: lock time: #{l_time}; " \
+                         "rerun flag time: #{r_time}; " \
+                         "process restarted since lock: #{p_start}"
         end
-        # release_lock will not matter if we are not holding the lock
-        release_lock(zk_hosts, lock_path, new_resource.lock_data)
+ 
+        # we should not get here if restarting the resource failed --
+        # so clean everything up
+        clear_rerun(node, lock_path)
+        begin
+          # release_lock will not matter if we are not holding the lock
+          release_lock(zk_hosts, lock_path, new_resource.lock_data)
+        rescue ::LockingResource::Helper::LockingResourceException => e
+          Chef::Log.warn e.message
+        end
       end
     end
   end
 end
-

--- a/test/cookbooks/locking_resource_test/metadata.rb
+++ b/test/cookbooks/locking_resource_test/metadata.rb
@@ -6,5 +6,5 @@ description      'Installs and configures locking_resource cookbook for testing'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.0'
 
-depends 'zookeeper', '=6.0.0'
+depends 'zookeeper', '>= 8.1.4'
 depends 'locking_resource'

--- a/test/cookbooks/locking_resource_test/recipes/default.rb
+++ b/test/cookbooks/locking_resource_test/recipes/default.rb
@@ -1,6 +1,4 @@
-node.default['zookeeper']['service_style'] = 'runit'
 include_recipe 'zookeeper::default'
-include_recipe 'runit'
 include_recipe 'zookeeper::service'
 include_recipe 'locking_resource::default'
 

--- a/test/cookbooks/locking_resource_test/recipes/held_serialized_lock.rb
+++ b/test/cookbooks/locking_resource_test/recipes/held_serialized_lock.rb
@@ -1,6 +1,4 @@
-node.default['zookeeper']['service_style'] = 'runit'
 include_recipe 'zookeeper::default'
-include_recipe 'runit'
 include_recipe 'zookeeper::service'
 include_recipe 'locking_resource::default'
 Chef::Recipe.send(:include, LockingResource::Helper)

--- a/test/cookbooks/locking_resource_test/recipes/re_run_lock_newer.rb
+++ b/test/cookbooks/locking_resource_test/recipes/re_run_lock_newer.rb
@@ -1,0 +1,48 @@
+include_recipe 'zookeeper::default'
+include_recipe 'zookeeper::service'
+include_recipe 'locking_resource::default'
+include_recipe 'locking_resource_test::re_run_lock_setup'
+Chef::Recipe.send(:include, LockingResource::Helper)
+Chef::Resource::RubyBlock.send(:include, LockingResource::Helper)
+
+###
+# This recipe is designed to run after re_run_lock_setup has created state
+# for resource failure
+# * Run a serialized process action with newer process running
+#   (should not execute -- but should clean-up state)
+#
+
+lock_resource = 'Dummy Resource One'
+lock_path = "ruby_block[#{lock_resource.gsub(' ', ':')}]"
+full_lock_path = ::File.join(node[:locking_resource][:restart_lock][:root],
+                             lock_path)
+test_process = '/bin/sleep 60'                                                  
+                                                                                
+ruby_block 'Run a test process' do                                              
+  block do                                                                      
+    # make sure we wait long enough that at a one second granularity the        
+    # state times and process start times are different                         
+    sleep(2)                                                                    
+    node.run_state[:child_pid] = spawn(test_process)                            
+  end                                                                           
+end  
+
+locking_resource 'Clean-up state (and not run) if process newer than lock' do
+  lock_name lock_path
+  resource "ruby_block[#{lock_resource}]"
+  process_pattern do
+    command_string test_process
+    full_cmd true
+  end
+  action :serialize_process
+  perform :run
+end
+
+ruby_block 'Check action not run and re-run state was cleaned up' do
+  block do
+    raise 'Ran action and should not have!' if \
+      node.run_state[:locking_resource_test][:ran_action]
+    re_run_state = node[:locking_resource][:failed_locks][full_lock_path]
+    raise "Re-run state not cleaned up: #{re_run_state}" if re_run_state
+  end
+end

--- a/test/cookbooks/locking_resource_test/recipes/re_run_lock_older.rb
+++ b/test/cookbooks/locking_resource_test/recipes/re_run_lock_older.rb
@@ -1,0 +1,37 @@
+include_recipe 'zookeeper::default'
+include_recipe 'zookeeper::service'
+include_recipe 'locking_resource::default'
+include_recipe 'locking_resource_test::re_run_lock_setup'
+Chef::Recipe.send(:include, LockingResource::Helper)
+Chef::Resource::RubyBlock.send(:include, LockingResource::Helper)
+
+####                                                                             
+## This recipe is designed to run after re_run_lock_setup has created state      
+## for resource failure                                                          
+## * Run a serialized process action with old process running (should execute)       
+##  
+
+lock_resource = 'Dummy Resource One'
+lock_path = "ruby_block[#{lock_resource.gsub(' ', ':')}]"
+full_lock_path = ::File.join(node[:locking_resource][:restart_lock][:root],
+                             lock_path)
+
+locking_resource 'We run if process older than first attempt' do
+  lock_name lock_path
+  resource "ruby_block[#{lock_resource}]"
+  process_pattern do
+    command_string 'init'
+    user 'root'
+  end
+  action :serialize_process
+  perform :run
+end
+
+ruby_block 'Check re-run state was cleaned up' do
+  block do
+    raise 'Did not run action!' unless \
+      node.run_state[:locking_resource_test][:ran_action]
+    re_run_state = node[:locking_resource][:failed_locks][full_lock_path]
+    raise "Re-run state not cleaned up: #{re_run_state}" if re_run_state
+  end
+end

--- a/test/cookbooks/locking_resource_test/recipes/re_run_lock_setup.rb
+++ b/test/cookbooks/locking_resource_test/recipes/re_run_lock_setup.rb
@@ -1,0 +1,93 @@
+include_recipe 'zookeeper::default'
+include_recipe 'zookeeper::service'
+include_recipe 'locking_resource::default'
+Chef::Recipe.send(:include, LockingResource::Helper)
+Chef::Resource::RubyBlock.send(:include, LockingResource::Helper)
+
+
+###
+# This recipe is designed to create a held lock and ensure we
+# don't run due to the lock (used by recipes to test handling once
+# lock released). Process:
+# * Create conflicting lock
+# * Run a serialized process action (should timeout)
+# * Run a serialized process action (should timeout again)
+# * Clear conflicting lock
+#
+
+# Reset failed_locks
+node.normal[:locking_resource][:failed_locks] = {}
+
+zk_hosts = parse_zk_hosts(node[:locking_resource][:zookeeper_servers])
+lock_resource = 'Dummy Resource One'
+lock_path = "ruby_block[#{lock_resource.gsub(' ', ':')}]"
+full_lock_path = ::File.join(node[:locking_resource][:restart_lock][:root],
+                             lock_path)
+node.run_state[:locking_resource_test] = {}
+node.run_state[:locking_resource_test][:ran_action] = false
+
+# Create the resources for us to serialize
+ruby_block lock_resource do
+  block do
+    Chef::Log.warn "Dummy resource -- which should run -- ran at: #{Time.now}"
+    node.run_state[:locking_resource_test][:ran_action] = true
+  end
+  action :nothing
+end
+
+ruby_block 'Create a blocking lock' do
+  block do
+    got_lock = create_node(zk_hosts, full_lock_path, 'foobar') and \
+        Chef::Log.warn "#{Time.now}: Acquired blocking lock"
+    raise 'Did not set lock' unless lock_matches?(zk_hosts, full_lock_path,
+                                                  'foobar')
+  end
+end
+
+# Try to run a serialized action -- timeout
+locking_resource 'Test we do not run with held lock -- should timeout' do
+  lock_name lock_path
+  resource "ruby_block[#{lock_resource}]"
+  perform :run
+  action :serialize
+  ignore_failure true
+end
+
+ruby_block 'Verify rerun state set' do
+  block do
+    raise 'Some how already ran' if \
+      node.run_state[:locking_resource_test][:ran_action]
+    re_run_parent = node[:locking_resource][:failed_locks]
+    raise "Re-run state not set #{re_run_parent}" unless \
+      re_run_parent.has_key?(full_lock_path)
+  end
+end
+
+# Still should not run the serialized action -- but verify we increment state
+# and ensure we don't run without the lock
+locking_resource 'ruby_block -- timeout again' do
+  lock_name lock_path
+  resource "ruby_block[#{lock_resource}]"
+  perform :run
+  action :serialize
+  ignore_failure true
+end
+
+ruby_block 'Verify rerun failures incremented' do
+  block do
+    raise 'Some how already ran' if \
+      node.run_state[:locking_resource_test][:ran_action]
+    fails = node[:locking_resource][:failed_locks][full_lock_path]['fails']
+    raise "Re-run state not incremented: #{fails}" unless fails == 2
+  end
+end
+
+ruby_block 'Clean-up the stale lock' do
+  block do
+    raise 'Some how already ran' if \
+      node.run_state[:locking_resource_test][:ran_action]
+    release_lock(zk_hosts, full_lock_path, 'foobar')
+    raise 'Did not release lock' if lock_matches?(zk_hosts, full_lock_path,
+                                                  'foobar')
+  end
+end

--- a/test/cookbooks/locking_resource_test/recipes/serialized_process_lock_handling.rb
+++ b/test/cookbooks/locking_resource_test/recipes/serialized_process_lock_handling.rb
@@ -1,6 +1,4 @@
-node.default['zookeeper']['service_style'] = 'runit'
 include_recipe 'zookeeper::default'
-include_recipe 'runit'
 include_recipe 'zookeeper::service'
 include_recipe 'locking_resource::default'
 Chef::Recipe.send(:include, LockingResource::Helper)

--- a/test/cookbooks/locking_resource_test/recipes/simple_serialized_lock.rb
+++ b/test/cookbooks/locking_resource_test/recipes/simple_serialized_lock.rb
@@ -1,6 +1,4 @@
-node.default['zookeeper']['service_style'] = 'runit'
 include_recipe 'zookeeper::default'
-include_recipe 'runit'
 include_recipe 'zookeeper::service'
 include_recipe 'locking_resource::default'
 

--- a/test/cookbooks/locking_resource_test/recipes/simple_serialized_process.rb
+++ b/test/cookbooks/locking_resource_test/recipes/simple_serialized_process.rb
@@ -1,6 +1,4 @@
-node.default['zookeeper']['service_style'] = 'runit'
 include_recipe 'zookeeper::default'
-include_recipe 'runit'
 include_recipe 'zookeeper::service'
 include_recipe 'locking_resource::default'
 


### PR DESCRIPTION
This provides code to keep track in the node object if a resource needs to be re-run in a later Chef run. Also exceptions are now fatal in the `locking_resource` resource to allow one to decide if failure should be allowed or not.

I'll have quite a bit of rubocop and foodcritic fixes coming after this but don't want to confuse things by including them here.