### PR TITLE
Lint cleanups

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,10 +7,13 @@ provisioner:
 
 platforms:
   - name: ubuntu-14.04
-    driver:
-      require_chef_omnibus: 12.13.37
     run_list:
     attributes: {
+      locking_resource: {
+        restart_lock_acquire: {
+          timeout: 3
+        }
+      }
     }
 suites:
   - name: simple_locking_resource
@@ -25,3 +28,9 @@ suites:
   - name: serialized_process
     run_list:
       - 'recipe[locking_resource_test::serialized_process_lock_handling]'
+  - name: re_run_lock_older
+    run_list:
+      - 'recipe[locking_resource_test::re_run_lock_older]'
+  - name: re_run_lock_newer
+    run_list:
+      - 'recipe[locking_resource_test::re_run_lock_newer]'

--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,10 @@
 source 'https://rubygems.org'
 ruby RUBY_VERSION
 
-gem 'zookeeper'
 gem 'poise'
+gem 'zookeeper'
 group :test do
-  gem 'rack'
-  gem 'simplecov'
-  gem 'chefspec'
   gem 'berkshelf'
-  gem 'buff-extensions'
+  gem 'chefspec'
+  gem 'simplecov'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,9 @@ ruby RUBY_VERSION
 gem 'zookeeper'
 gem 'poise'
 group :test do
-  gem 'rack', '< 2'
+  gem 'rack'
   gem 'simplecov'
   gem 'chefspec'
   gem 'berkshelf'
-  gem 'buff-extensions', '~> 1.0'
+  gem 'buff-extensions'
 end

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Contributing
 ============
 Contributions are welcomed! This cookbook tries to have rigorous testing to verify that locks are held and released as expected. The current process for kicking these off on a machine with ChefDK is:
 ````
-$ bundler --path=vendor/cache
+$ export PATH=/opt/chefdk/embedded/bin:$PATH
+$ bundler package --path=vendor/cache
 $ berks vendor
 $ bundler exec rspec
 $ kitchen converge '.*'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,14 +5,16 @@
 #############################################
 # The path in ZK where the restart locks (znodes)  need to be created
 # The path should exist in ZooKeeper e.g. '/lock'
-default[:locking_resource][:restart_lock][:root] = '/lock'
+default['locking_resource']['restart_lock']['root'] = '/lock'
+# Where we store failed lock attempts to run in a future Chef run
+default['locking_resource']['failed_locks'] = {}
 # Sleep time in seconds between tries to acquire the lock for restart
-default[:locking_resource][:restart_lock_acquire][:sleep_time] = 0.25
+default['locking_resource']['restart_lock_acquire']['sleep_time'] = 0.25
 # Timeout in seconds before failing to acquire lock
-default[:locking_resource][:restart_lock_acquire][:timeout] = 30
+default['locking_resource']['restart_lock_acquire']['timeout'] = 30
 # Flag to control whether automatic restarts due to config changes need to be
 # skipped for e.g. if ZK quorum is down or if the recipes need to be run in a
 # non ZK env
-default[:locking_resource][:skip_restart_coordination] = false
+default['locking_resource']['skip_restart_coordination'] = false
 # The default zookeeper quorum
-default[:locking_resource][:zookeeper_servers] = ['localhost:2181']
+default['locking_resource']['zookeeper_servers'] = ['localhost:2181']

--- a/libraries/locking_resource.rb
+++ b/libraries/locking_resource.rb
@@ -48,20 +48,20 @@ class Chef
     def acquire_lock(zk_hosts, lock_path, lock_data, timeout, retry_time)
       Chef::Log.info "Acquiring lock #{lock_path}"
       # acquire lock
-      # rubocop:disable 'no-and-or-or'
+      # rubocop:disable Style/AndOr
       got_lock = lock_matches?(zk_hosts, lock_path, lock_data) \
         and Chef::Log.info 'Found stale lock'
-      # rubocop:enable 'no-and-or-or'
+      # rubocop:enable Style/AndOr
 
       # intentionally do not use a timeout to avoid leaving a wonky
       # zookeeper object or connection if we interrupt it -- thus we trust
       # the zookeeper object to not wantonly hang
       start_time = Time.now
       while !got_lock && (start_time + timeout) >= Time.now
-        # rubocop:disable 'no-and-or-or'
+        # rubocop:disable Style/AndOr
         got_lock = create_node(zk_hosts, lock_path, lock_data) \
           and Chef::Log.info 'Acquired new lock'
-        # rubocop:enable 'no-and-or-or'
+        # rubocop:enable Style/AndOr
         sleep(retry_time)
         Chef::Log.warn "Sleeping for lock #{lock_path}"
       end

--- a/libraries/locking_resource.rb
+++ b/libraries/locking_resource.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: locking_resource
 # Library:: locking_resource
 #
-# Copyright (C) 2016 Bloomberg Finance L.P.
+# Copyright (C) 2017 Bloomberg Finance L.P.
 #
 require 'poise'
 require 'set'
@@ -16,13 +16,17 @@ class Chef
     default_action(:serialize)
 
     attribute(:name, kind_of: String)
+    attribute(:lock_name, kind_of: String, default: nil)
     attribute(:resource, kind_of: String, required: true)
     attribute(:perform, kind_of: Symbol, required: true)
-    attribute(:timeout, kind_of: Integer, default: lazy { node[:locking_resource][:restart_lock_acquire][:timeout] })
+    attribute(:timeout, kind_of: Integer, default: \
+      lazy { node['locking_resource']['restart_lock_acquire']['timeout'] })
+    attribute(:zookeeper_hosts, kind_of: Array, default: \
+      lazy { node['locking_resource']['zookeeper_servers'] })
     attribute(:process_pattern, option_collector: true)
-    attribute(:lock_data, kind_of: String, default: lazy { node[:fqdn] })
+    attribute(:lock_data, kind_of: String, default: lazy { node['fqdn'] })
 
-    # XXX should validate node[:locking_resource][:zookeeper_servers] parses
+    # XXX should validate node['locking_resource']['zookeeper_servers'] parses
   end
 
   class Provider::LockingResource < Provider
@@ -31,99 +35,170 @@ class Chef
     include ::LockingResource::Helper
     provides(:locking_resource)
 
+    #
+    # Loops trying to acquire lock and returns true if lock acquired,
+    # false otherwise
+    # Inputs:
+    #   zk_hosts   - a string of <host>:<port>,<host>:<port>,... for ZK hosts
+    #   lock_path  - the path for the lock
+    #   lock_data  - the data to record in the lock, if we acquire the lock
+    #   timeout    - the overall time to try acquiring the lock
+    #   retry_time - the time to re-try acquiring the lock (should be less
+    #                than and a multiple of the total timeout)
+    def acquire_lock(zk_hosts, lock_path, lock_data, timeout, retry_time)
+      Chef::Log.info "Acquiring lock #{lock_path}"
+      # acquire lock
+      # rubocop:disable no-and-or-or
+      got_lock = lock_matches?(zk_hosts, lock_path, lock_data)\
+        and Chef::Log.info 'Found stale lock'
+      # rubocop:enable no-and-or-or
+
+      # intentionally do not use a timeout to avoid leaving a wonky
+      # zookeeper object or connection if we interrupt it -- thus we trust
+      # the zookeeper object to not wantonly hang
+      start_time = Time.now
+      while !got_lock && (start_time + timeout) >= Time.now
+        # rubocop:disable no-and-or-or
+        got_lock = create_node(zk_hosts, lock_path, lock_data)\
+          and Chef::Log.info 'Acquired new lock'
+        # rubocop:enable no-and-or-or
+        sleep(retry_time)
+        Chef::Log.warn "Sleeping for lock #{lock_path}"
+      end
+      # see if we ever got a lock -- if not record it for later
+      if !got_lock
+        Chef::Log.warn "Did not get lock #{lock_path}"
+      end
+      got_lock
+    end
+
+    #
+    # Used to action a resource with locking semantics
     def action_serialize
-      converge_by("serializing #{new_resource.name} via lock") do
+      converge_by("serializing #{new_resource.name}") do
         r = run_context.resource_collection.resources(new_resource.resource)
+        fail "Unable to find resource #{new_resource.resource} in " \
+             'resources' unless r
 
         # to avoid namespace collisions replace spaces in resource name with
         # a colon -- zookeeper's quite permissive on paths:
         # https://zookeeper.apache.org/doc/trunk/zookeeperProgrammers.html#ch_zkDataModel
-        lock_path = ::File.join(node[:locking_resource][:restart_lock][:root],
-                              new_resource.name.gsub(' ', ':'))
+        lock_name = new_resource.lock_name || new_resource.name.tr_s(' ', ':')
+        lock_path = ::File.join(
+          node['locking_resource']['restart_lock']['root'],
+          lock_name
+        )
 
-        unless node[:locking_resource][:skip_restart_coordination]
-          zk_hosts = parse_zk_hosts(node[:locking_resource][:zookeeper_servers])
-
-          Chef::Log.info "Acquiring lock #{lock_path}"
-          # acquire lock
-          got_lock = lock_matches?(zk_hosts, lock_path, new_resource.lock_data) and \
-            Chef::Log.info "Found stale lock"
-          # intentionally do not use a timeout to avoid leaving a wonky zookeeper
-          # object or connection if we interrupt it -- thus we trust the
-          # zookeeper object to not wantonly hang
-          start_time = Time.now
-          while !got_lock && (start_time + new_resource.timeout) >= Time.now
-            got_lock = create_node(zk_hosts, lock_path, new_resource.lock_data) and \
-              Chef::Log.info 'Acquired new lock'
-            sleep(node[:locking_resource][:restart_lock_acquire][:sleep_time])
-          end
-        else
+        zk_hosts = parse_zk_hosts(new_resource.zookeeper_hosts)
+        if node['locking_resource']['skip_restart_coordination']
+          got_lock = false
           Chef::Log.warn 'Restart coordination disabled -- skipping lock ' \
                          "acquisition on #{lock_path}"
+        else
+          loop_time = \
+            node['locking_resource']['restart_lock_acquire']['sleep_time']
+          got_lock = acquire_lock(zk_hosts, lock_path, new_resource.lock_data,
+                                  new_resource.timeout, loop_time)
         end
 
         # affect the resource, if we got the lock -- or error
-        if got_lock or node[:locking_resource][:skip_restart_coordination]
+        if got_lock || node['locking_resource']['skip_restart_coordination']
           notifying_block do
             r.run_action new_resource.perform
             r.resolve_notification_references
             new_resource.updated_by_last_action(r.updated)
-            release_lock(zk_hosts, lock_path, new_resource.lock_data)
+            begin
+              release_lock(zk_hosts, lock_path, new_resource.lock_data)
+            rescue ::LockingResource::Helper::LockingResourceException => e
+              Chef::Log.warn e.message
+            end
           end
         else
-          raise 'Failed to acquire lock for ' +
+          need_rerun(node, lock_path)
+          fail 'Failed to acquire lock for ' \
                 "LockingResource[#{new_resource.name}], path #{lock_path}"
         end
       end
     end
 
     # Only restart the service if we are holding the lock
-    # and the service has not restarted since we got the lock
+    # and the service has not restarted since we started trying to get the lock
     def action_serialize_process
       vppo = ::LockingResource::Helper::VALID_PROCESS_PATTERN_OPTS
-      raise "Need a process pattern attribute" unless \
-        new_resource.process_pattern.length != 0
-      raise "Only expect options: #{vppo.keys} but got " \
-        "#{new_resource.process_pattern.keys}" if \
-        Set.new(new_resource.process_pattern.keys) < \
+      raise 'Need a process pattern attribute' unless \
+        !new_resource.process_pattern.empty?
+      if Set.new(new_resource.process_pattern.keys) < \
         Set.new(vppo.keys)
-      converge_by("serializing as process #{new_resource.name} via lock") do
+        raise "Only expect options: #{vppo.keys} but got " \
+          "#{new_resource.process_pattern.keys}"
+      end
+      converge_by("serializing #{new_resource.name} on process") do
+        l_time = false
+        lock_and_rerun = false
+
         r = run_context.resource_collection.resources(new_resource.resource)
+        zk_hosts = parse_zk_hosts(new_resource.zookeeper_hosts)
+
         # convert keys from strings to symbols for process_start_time()
-        start_time_args = new_resource.process_pattern.inject({}) do |memo,(k,v)|
+        start_time_arg = \
+            new_resource.process_pattern.inject({}) do |memo, (k, v)|
           memo[k.to_sym] = v
           memo
         end
-        p_start = process_start_time(start_time_args)
 
-        # if the process is not running we do not care about lock management --
-        # just run the action
+        p_start = process_start_time(start_time_arg) || false
+
+        # questionable if we want to include cookbook_name and recipe_name in
+        # the lock as we may have multiple resources with the same name
+        lock_name = new_resource.lock_name || new_resource.name.tr_s(' ', ':')
+        lock_path = ::File.join(
+          node['locking_resource']['restart_lock']['root'],
+          lock_name
+        )
+
+        r_time = rerun_time?(node, lock_path)
+        begin
+          got_lock = lock_matches?(zk_hosts, lock_path, new_resource.lock_data)
+          l_time = get_node_ctime(zk_hosts, lock_path) if got_lock
+        rescue ::LockingResource::Helper::LockingResourceException => e
+          Chef::Log.warn e.message
+        end
+        Chef::Log.warn 'Found stale lock' if got_lock
+
+        # if process is started see if we need to restart it again
         if p_start
-          lock_path = ::File.join(node[:locking_resource][:restart_lock][:root],
-                                  new_resource.name.gsub(' ', ':'))
-          zk_hosts = parse_zk_hosts(node[:locking_resource][:zookeeper_servers])
-
-          got_lock = lock_matches?(zk_hosts, lock_path, new_resource.lock_data) or return
-          l_time = get_node_ctime(zk_hosts, lock_path)
-          Chef::Log.warn "Found stale lock" if got_lock
+          node_rerun_needed = p_start <= (r_time || Time.new(0))
+          lock_rerun_needed = p_start <= (l_time || Time.new(0))
+          lock_and_rerun = node_rerun_needed || lock_rerun_needed
         end
 
-        if !p_start or p_start <= l_time
-          Chef::Log.warn "Restarting process: lock time " \
-                         "#{l_time}; process restarted #{p_start}"
+        # if we are not running the process -- run! Otherwise if we have a
+        # past, failed restart attempt, re-run
+        if !p_start || lock_and_rerun
+          Chef::Log.info 'Restarting process: lock time: ' \
+                         "#{l_time}; rerun flag time: #{r_time}; " \
+                         "process restarted since lock: #{p_start}"
           notifying_block do
             r.run_action new_resource.perform
             r.resolve_notification_references
             new_resource.updated_by_last_action(r.updated)
           end
         else
-          Chef::Log.warn "Not restarting process: lock time " \
-                         "#{l_time}; process restarted #{p_start}"
+          Chef::Log.info "Not restarting process: lock time: #{l_time}; " \
+                         "rerun flag time: #{r_time}; " \
+                         "process restarted since lock: #{p_start}"
         end
-        # release_lock will not matter if we are not holding the lock
-        release_lock(zk_hosts, lock_path, new_resource.lock_data)
+ 
+        # we should not get here if restarting the resource failed --
+        # so clean everything up
+        clear_rerun(node, lock_path)
+        begin
+          # release_lock will not matter if we are not holding the lock
+          release_lock(zk_hosts, lock_path, new_resource.lock_data)
+        rescue ::LockingResource::Helper::LockingResourceException => e
+          Chef::Log.warn e.message
+        end
       end
     end
   end
 end
-

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,8 +1,11 @@
 if defined?(ChefSpec)
   def serialize_locking_resource(resource_name)
-    ChefSpec::Matchers::ResourceMatcher.new(:locking_resource, :serialize, resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:locking_resource,
+                                            :serialize, resource_name)
   end
+
   def serialize_process_locking_resource(resource_name)
-    ChefSpec::Matchers::ResourceMatcher.new(:locking_resource, :serialize_process, resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:locking_resource,
+                                            :serialize_process, resource_name)
   end
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,26 +24,26 @@
 # Chef 11 Omnibus)
 require 'pathname'
 require 'rubygems'
-gem_path = Pathname.new(Gem.ruby).dirname.join("gem").to_s
+gem_path = Pathname.new(Gem.ruby).dirname.join('gem').to_s
 
 # build requirements for zookeeper
-%w{make patch gcc}.each do |pkg|
+%w(make patch gcc).each do |pkg|
   package pkg do
     action :nothing
   end.run_action(:install)
 end
 
-gem_package "zookeeper" do
-    gem_binary gem_path
-    version ">0.0"
-    action :nothing
+gem_package 'zookeeper' do
+  gem_binary gem_path
+  version '>0.0'
+  action :nothing
 end.run_action(:install)
 
 # work around funky umasks
-execute "correct-gem-permissions" do
-  command "find #{Gem.default_dir()} -type f -exec chmod a+r {} \\; && " +
-          "find #{Gem.default_dir()} -type d -exec chmod a+rx {} \\;"
-  user "root"
+execute 'correct-gem-permissions' do
+  command "find #{Gem.default_dir} -type f -exec chmod a+r {} \\; && " \
+          "find #{Gem.default_dir} -type d -exec chmod a+rx {} \\;"
+  user 'root'
   action :nothing
 end.run_action(:run)
 

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -3,26 +3,20 @@ require 'chefspec'
 describe 'locking_resource::default' do
   let :chef_run do
     ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '14.04',
-                             cookbook_path: File.join(File.expand_path(Dir.pwd), 'berks-cookbooks'))
+                             cookbook_path: File.join(File.expand_path(Dir.pwd),
+                                                      'berks-cookbooks'))
   end
 
   it 'should serialize locking resource' do
     chef_run.converge(described_recipe)
-    %w{make patch gcc}.each do|pkg|
+    %w(make patch gcc).each do |pkg|
       expect(chef_run).to install_package(pkg)
     end
     expect(chef_run).to install_gem_package('zookeeper')
     expect(chef_run).to run_execute('correct-gem-permissions')
-    allow(Gem).to receive(:clear_paths) 
+    allow(Gem).to receive(:clear_paths)
     allow(Gem).to receive(:clear_paths).and_return(true)
-    allow(Kernel).to receive(:require) 
-    allow(Kernel).to receive(:require).with("zookeeper").and_return(true)
+    allow(Kernel).to receive(:require)
+    allow(Kernel).to receive(:require).with('zookeeper').and_return(true)
   end
 end
-
-#execute "correct-gem-permissions" do
-#  command "find #{Gem.default_dir()} -type f -exec chmod a+r {} \\; && " +
-#          "find #{Gem.default_dir()} -type d -exec chmod a+rx {} \\;"
-#  user "root"
-#  action :nothing
-#end.run_action(:run)

--- a/spec/locking_resource_test_spec.rb
+++ b/spec/locking_resource_test_spec.rb
@@ -20,7 +20,7 @@ describe 'locking_resource_test::simple_serialized_lock' do
       allow_any_instance_of(Chef::Provider::LockingResource).to \
         receive(:lock_matches?).and_return(false)
       allow_any_instance_of(Chef::Provider::LockingResource).to \
-        receive(:create_node) 
+        receive(:create_node)
       allow_any_instance_of(Chef::Provider::LockingResource).to \
         receive(:create_node).and_return(true)
       allow_any_instance_of(Chef::Provider::LockingResource).to \
@@ -28,7 +28,6 @@ describe 'locking_resource_test::simple_serialized_lock' do
       chef_run.converge(described_recipe)
       expect(chef_run).to write_log('This is a dummy resource')
     end
-
   end
 
   context 'locking disabled' do
@@ -37,7 +36,8 @@ describe 'locking_resource_test::simple_serialized_lock' do
                                cookbook_path: cookbook_path,
                                step_into: ['locking_resource']) do |node|
         node.override[:locking_resource][:skip_restart_coordination] = true
-        node.override[:locking_resource][:zookeeper_servers] = ['localhost:2181']
+        node.override[:locking_resource][:zookeeper_servers] = \
+          ['localhost:2181']
       end
     end
 
@@ -77,7 +77,7 @@ describe 'locking_resource_test::simple_serialized_process' do
       allow_any_instance_of(Chef::Provider::LockingResource).to \
         receive(:lock_matches?).and_return(true)
       allow_any_instance_of(Chef::Provider::LockingResource).to \
-        receive(:process_start_time).and_return(Time.now-5)
+        receive(:process_start_time).and_return(Time.now - 5)
       allow_any_instance_of(Chef::Provider::LockingResource).to \
         receive(:get_node_ctime).and_return(Time.now)
       allow_any_instance_of(Chef::Provider::LockingResource).to \
@@ -101,9 +101,9 @@ describe 'locking_resource_test::simple_serialized_process' do
       allow_any_instance_of(Chef::Provider::LockingResource).to \
         receive(:lock_matches?).and_return(true)
       allow_any_instance_of(Chef::Provider::LockingResource).to \
-        receive(:process_start_time).and_return(Time.now+5)
+        receive(:process_start_time).and_return(Time.now + 5)
       allow_any_instance_of(Chef::Provider::LockingResource).to \
-        receive(:get_node_ctime).and_return(Time.now-15)
+        receive(:get_node_ctime).and_return(Time.now - 15)
       allow_any_instance_of(Chef::Provider::LockingResource).to \
         receive(:release_lock).and_return(true)
       chef_run.converge(described_recipe)
@@ -120,7 +120,8 @@ describe 'locking_resource_test::simple_serialized_process' do
 
     it 'should log if lock not present' do
       chef_run.converge(described_recipe)
-      expect(chef_run).to serialize_process_locking_resource('Test we run if process dead')
+      expect(chef_run).to \
+        serialize_process_locking_resource('Test we run if process dead')
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,14 +2,14 @@ require 'simplecov'
 require 'chefspec'
 require 'chefspec/berkshelf'
 
-if not defined?(Log)
+unless defined?(Log)
   require 'mixlib/log'
   class Log
     extend Mixlib::Log
   end
 end
 
-formatters = [ SimpleCov::Formatter::HTMLFormatter ]
+formatters = [SimpleCov::Formatter::HTMLFormatter]
 
 begin
   require 'simplecov-json'
@@ -37,18 +37,15 @@ RSpec.configure do |config|
   config.order = :random
 
   # run as though rspec --format documentation when passing a single spec file
-  if config.files_to_run.one?
-    config.default_formatter = 'doc'
-  end
+  config.default_formatter = 'doc' if config.files_to_run.one?
 
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = true
   end
 
-  berks = Berkshelf::Berksfile.from_file('Berksfile').install()
+  Berkshelf::Berksfile.from_file('Berksfile').install
 end
 
-
 at_exit do
- ChefSpec::Coverage.report!
+  ChefSpec::Coverage.report!
 end

--- a/spec/unit/helper_spec.rb
+++ b/spec/unit/helper_spec.rb
@@ -377,88 +377,13 @@ describe LockingResource::Helper do
                  exitstatus: 0,
                  stdout: '',
                  stderr: error_string,
-                 live_stream: ''
-                )
+                 live_stream: '')
         end.exactly(1).times
         expect do
           dummy_class.new.process_start_time(full_cmd: true,
                                              command_string: test_command)
         end.to raise_error(error_string)
       end
-
-# Can not seem to get standard out stub to work
-# Randomized with seed 15068
-#
-#LockingResource::Helper
-#  #process_start_time?
-#    process exists
-#XXX early_idx 0; PIDs: [29371, 6114]
-#XXX3 Happy run - earliest time!
-#XXX early_idx 0; PIDs: [29371, 6114]
-#XXX0 return_stdout Arg: pgrep -f "my command"
-#XXX1 pgrep output: 29371
-#6114
-#XXXlib pgrep , XXX 29371
-#6114
-#XXX3 Happy run - earliest time!
-#XXX early_idx 0; PIDs: [29371, 6114]
-#XXX0 return_stdout Arg: ps --no-header -o lstart 29371
-#XXX1 Returning early
-#XXXlib ps , XXX Tue Jul 12 14:38:34 2016
-#XXX3 Happy run - earliest time!
-#XXX early_idx 0; PIDs: [29371, 6114]
-#XXX0 return_stdout Arg: ps --no-header -o lstart 6114
-#XXX1 Returning late
-#XXXlib ps , XXX Sat Jul 30 18:48:45 2016
-#      returns the earliest time
-#XXX early_idx ; PIDs: []
-#Early idx:
-#      raises under ps error (FAILED - 1)
-#
-#Failures:
-#
-#  1) LockingResource::Helper#process_start_time? process exists raises under ps error
-#     Failure/Error:
-#       expect { dummy_class.new.process_start_time(command_string) }.to \
-#         raise_error(error_string)
-#
-#       expected Exception with "TEST: We got an error", got #<NoMethodError: undefined method `+' for nil:NilClass> with backtrace:
-#         # ./spec/unit/helper_spec.rb:64:in `block (5 levels) in <top (required)>'
-#         # ./libraries/helpers.rb:175:in `process_start_time'
-#         # ./spec/unit/helper_spec.rb:80:in `block (5 levels) in <top (required)>'
-#         # ./spec/unit/helper_spec.rb:80:in `block (4 levels) in <top (required)>'
-#     # ./spec/unit/helper_spec.rb:80:in `block (4 levels) in <top (required)>'
-#
-
-#     it 'raises under ps error' do
-#       puts "XXX early_idx #{early_idx}; PIDs: #{pids}"
-#       # we need to use and_wrap_original since we mutate the double based
-#       # on the argument passed in per
-#       # https://www.relishapp.com/rspec/rspec-mocks/v/3-2/docs/
-#       #         configuring-responses/wrapping-the-original-implementation
-#       counter = 1
-#       puts "Early idx: #{rand(0..pids.length-1)}"
-#       expect(Mixlib::ShellOut).to receive(:new).\
-#                                and_wrap_original do |orig, arg|
-#         puts "XXX2 Expected #{early_idx + 1}; #{counter}"
-#         counter += 1
-#         puts "XXX2 shellout arg: #{arg}|"
-#         puts "XXX2 shellout pgrep: #{return_stdout(arg)}|" if arg.start_with?('pgrep')
-#         puts "XXX2 shellout ps: #{return_stdout(arg)}|" if arg.start_with?('ps')
-#         puts "XXX2 expected fail pid index: #{early_idx}|"
-#         double({ run_command: nil,
-#           error!: (arg.start_with?('ps') && \
-#                     arg.end_with?(pids[early_idx])) ? error_string : '',
-#           exitstatus: 0,
-#           stdout: return_stdout(arg),
-#           stderr: (arg.start_with?('ps') && \
-#                     arg.end_with?(pids[early_idx])) ? error_string : '',
-#           live_stream: ''
-#         })
-#       end
-#       expect { dummy_class.new.process_start_time(command_string) }.to \
-#         raise_error(error_string)
-#     end
 
       it 'returns the earliest time' do
         expect(Mixlib::ShellOut).to receive(:new) do |arg|
@@ -467,12 +392,11 @@ describe LockingResource::Helper do
                  exitstatus: 0,
                  stdout: return_stdout(arg),
                  stderr: '',
-                 live_stream: ''
-                )
+                 live_stream: '')
         end.exactly(2).times
         expect(dummy_class.new.process_start_time(
-          full_cmd: true, command_string: test_command).to_i).to \
-            eq(Time.parse(ps_output).to_i)
+          full_cmd: true, command_string: test_command
+        ).to_i).to eq(Time.parse(ps_output).to_i)
       end
     end
   end
@@ -483,10 +407,6 @@ describe LockingResource::Helper do
         include LockingResource::Helper
       end
     end
-
-    #def need_rerun(node, path)
-    #def rerun_time?(node, path)
-    #def clear_rerun(node, path)
 
     context 'test node has had reruns set' do
       let(:node) { Chef::Node.new }

--- a/spec/unit/helper_spec.rb
+++ b/spec/unit/helper_spec.rb
@@ -15,61 +15,65 @@ describe LockingResource::Helper do
       let(:hosts) { 'localtest_no_host_to_connect:2181' }
       let(:my_data) { 'my_data' }
       let(:exception_str) { 'Error from test - should be logged' }
-    
+
       it 'creates necessary path and returns true' do
-        expect(dummy_class).to receive(:get_node_data). \
-          with(hosts, node_path) { false }
-        expect(dummy_class).to receive(:get_node_data). \
-          with(hosts, File.dirname(node_path)) { false }
-        expect(dummy_class).to receive(:get_node_data). \
-          with(hosts, node_path) { false }
-        dbl = double({ connected?: true,
-                       closed?: true })
+        expect(dummy_class).to receive(:get_node_data) \
+          .with(hosts, node_path) { false }
+        expect(dummy_class).to receive(:get_node_data) \
+          .with(hosts, File.dirname(node_path)) { false }
+        expect(dummy_class).to receive(:get_node_data) \
+          .with(hosts, node_path) { false }
+        dbl = double(connected?: true,
+                     closed?: true)
         expect(Zookeeper).to receive(:new) { dbl }
-        expect(dbl).to receive(:create).with({:path => ::File.dirname(node_path), :data => ''}).exactly(1).times{ {:rc => 0} }
+        expect(dbl).to receive(:create) \
+          .with(path: ::File.dirname(node_path), data: '') \
+          .exactly(1).times { { rc: 0 } }
         expect(Zookeeper).to receive(:new) { dbl }
-        expect(dbl).to receive(:create).with({:path => node_path, :data => my_data}).exactly(1).times{{:rc => 0}}
+        expect(dbl).to receive(:create) \
+          .with(path: node_path, data: my_data) \
+          .exactly(1).times { { rc: 0 } }
         expect(dummy_class.create_node(hosts, node_path,
-          my_data)).to match(true)
+                                       my_data)).to match(true)
       end
 
       it 'swallows exception and returns true' do
         # create_node tests for mkdir -p equiv
-        expect(dummy_class).to receive(:get_node_data). \
-          with(hosts, node_path) { false }
-        expect(dummy_class).to receive(:get_node_data). \
-          with(hosts, File.dirname(node_path)) { false }
-        expect(dummy_class).to receive(:get_node_data). \
-          with(hosts, node_path) { false }
+        expect(dummy_class).to receive(:get_node_data) \
+          .with(hosts, node_path) { false }
+        expect(dummy_class).to receive(:get_node_data) \
+          .with(hosts, File.dirname(node_path)) { false }
+        expect(dummy_class).to receive(:get_node_data) \
+          .with(hosts, node_path) { false }
         # create nodes for mkdir -p equiv
-        dbl = double({ connected?: true,
-                       create: {"rc".to_sym => 0},
-                       closed?: true })
+        dbl = double(connected?: true,
+                     create: { 'rc'.to_sym => 0 },
+                     closed?: true)
         expect(Zookeeper).to receive(:new) { dbl }
         # actual test
-        dbl = double({ connected?: true,
-                       create: {"rc".to_sym => 0}})
+        dbl = double(connected?: true,
+                     create: { 'rc'.to_sym => 0 })
         expect(Zookeeper).to receive(:new) { dbl }
         expect(dbl).to receive(:closed?).and_raise(exception_str)
         expect(Chef::Log).to receive(:warn).with(exception_str)
         expect(dbl).to receive(:closed?).and_raise(exception_str)
         expect(Chef::Log).to receive(:warn).with(exception_str)
         expect(dummy_class.create_node(hosts, node_path,
-          my_data)).to match(true)
+                                       my_data)).to match(true)
       end
-    
+
       it 'returns true if node created' do
-        expect(dummy_class).to receive(:get_node_data). \
-          with(hosts, node_path) { true }
-        dbl = double({ connected?: true,
-                   create: {"rc".to_sym => 0},
-                   closed?: true })
+        expect(dummy_class).to receive(:get_node_data) \
+          .with(hosts, node_path) { true }
+        dbl = double(connected?: true,
+                     create: { 'rc'.to_sym => 0 },
+                     closed?: true)
         expect(Zookeeper).to receive(:new) { dbl }
         expect(dummy_class.create_node(hosts, node_path,
-          my_data)).to match(true)
+                                       my_data)).to match(true)
       end
     end
-  end 
+  end
 
   describe '#lock_matches?' do
     let(:dummy_class) do
@@ -84,44 +88,43 @@ describe LockingResource::Helper do
       let(:hosts) { 'localtest_no_host_to_connect:2181' }
       let(:my_data) { 'my_data' }
       let(:exception_str) { 'Error from test - should be logged' }
-      let(:dbl) { double() }
-    
+      let(:dbl) { double }
+
       it 'returns true if lock matches' do
-        expect(Zookeeper).to receive(:new).with(hosts).exactly(1).times{ dbl }
-        expect(dbl).to receive(:connected?).exactly(1).times{ true }
-        expect(dbl).to receive(:get).with(:path => node_path).exactly(1).\
-          times{ {:data => my_data} }
-        expect(dbl).to receive(:closed?).exactly(1).times{ false }
+        expect(Zookeeper).to receive(:new).with(hosts).exactly(1).times { dbl }
+        expect(dbl).to receive(:connected?).exactly(1).times { true }
+        expect(dbl).to receive(:get).with(path: node_path).exactly(1) \
+                                    .times { { data: my_data } }
+        expect(dbl).to receive(:closed?).exactly(1).times { false }
         expect(dbl).to receive(:close).exactly(1).times
         expect(dummy_class.lock_matches?(hosts, node_path,
-          my_data)).to match(true)
+                                         my_data)).to match(true)
       end
-    
+
       it 'returns false if lock does not match' do
-        expect(Zookeeper).to receive(:new).with(hosts).exactly(1).times{ dbl }
-        expect(dbl).to receive(:connected?).exactly(1).times{ true }
-        expect(dbl).to receive(:get).with(:path => node_path).exactly(1).\
-          times{ {:data => 'random stuff'} }
-        expect(dbl).to receive(:closed?).exactly(1).times{ false }
+        expect(Zookeeper).to receive(:new).with(hosts).exactly(1).times { dbl }
+        expect(dbl).to receive(:connected?).exactly(1).times { true }
+        expect(dbl).to receive(:get).with(path: node_path).exactly(1) \
+                                    .times { { data: 'random stuff' } }
+        expect(dbl).to receive(:closed?).exactly(1).times { false }
         expect(dbl).to receive(:close).exactly(1).times
         expect(dummy_class.lock_matches?(hosts, node_path,
-          my_data)).to match(false)
+                                         my_data)).to match(false)
       end
-    
+
       it 'swallows an exception in Zk.close and returns true' do
-        expect(Zookeeper).to receive(:new).with(hosts).exactly(1).times{ dbl }
-        expect(dbl).to receive(:connected?).exactly(1).times{ true }
-        expect(dbl).to receive(:get).with(:path => node_path).exactly(1).\
-          times{ {:data => my_data} }
-        expect(dbl).to receive(:closed?).exactly(1).times{ false }
+        expect(Zookeeper).to receive(:new).with(hosts).exactly(1).times { dbl }
+        expect(dbl).to receive(:connected?).exactly(1).times { true }
+        expect(dbl).to receive(:get).with(path: node_path).exactly(1) \
+                                    .times { { data: my_data } }
+        expect(dbl).to receive(:closed?).exactly(1).times { false }
         expect(dbl).to receive(:close).exactly(1).times.and_raise(exception_str)
         expect(Chef::Log).to receive(:warn).with(exception_str)
         expect(dummy_class.lock_matches?(hosts, node_path,
-          my_data)).to match(true)
+                                         my_data)).to match(true)
       end
     end
   end
-
 
   describe '#release_lock' do
     let(:dummy_class) do
@@ -135,30 +138,32 @@ describe LockingResource::Helper do
       let(:node_path) { '/my_test_path/a_node' }
       let(:hosts) { 'localtest_no_host_to_connect:2181' }
       let(:my_data) { 'my_data' }
-      let(:exception_str) {
-        'release_lock: node does not contain expected data ' +
-        'not releasing the lock' }
-      let(:dbl) { double() }
-    
+      let(:exception_str) do
+        'release_lock: node does not contain expected data ' \
+          'not releasing the lock'
+      end
+      let(:dbl) { double }
+
       it 'returns true if lock matches' do
-        expect(Zookeeper).to receive(:new).with(hosts).exactly(1).times{ dbl }
-        expect(dbl).to receive(:connected?).exactly(1).times{ true }
-        expect(dummy_class).to receive(:lock_matches?).\
-          with(hosts, node_path, my_data).exactly(1).times{ true }
-        expect(dbl).to receive(:delete).exactly(1).times.\
-          with(:path => node_path){ {"rc".to_sym => 0} }
-        expect(dbl).to receive(:closed?).exactly(1).times{ false }
+        expect(Zookeeper).to receive(:new).with(hosts).exactly(1).times { dbl }
+        expect(dbl).to receive(:connected?).exactly(1).times { true }
+        expect(dummy_class).to receive(:lock_matches?) \
+          .with(hosts, node_path, my_data).exactly(1).times { true }
+        expect(dbl).to receive(:delete) \
+          .exactly(1).times \
+          .with(path: node_path) { { 'rc'.to_sym => 0 } }
+        expect(dbl).to receive(:closed?).exactly(1).times { false }
         expect(dbl).to receive(:close).exactly(1).times
         expect(dummy_class.release_lock(hosts, node_path,
-          my_data)).to match(true)
+                                        my_data)).to match(true)
       end
 
       it 'returns false if lock does not match' do
-        expect(Zookeeper).to receive(:new).with(hosts).exactly(1).times{ dbl }
-        expect(dbl).to receive(:connected?).exactly(1).times{ true }
-        expect(dummy_class).to receive(:lock_matches?).\
-          with(hosts, node_path, my_data).exactly(1).times{ false }
-        expect(dbl).to receive(:closed?).exactly(1).times{ false }
+        expect(Zookeeper).to receive(:new).with(hosts).exactly(1).times { dbl }
+        expect(dbl).to receive(:connected?).exactly(1).times { true }
+        expect(dummy_class).to receive(:lock_matches?) \
+          .with(hosts, node_path, my_data).exactly(1).times { false }
+        expect(dbl).to receive(:closed?).exactly(1).times { false }
         expect(dbl).to receive(:close).exactly(1).times
         expect do
           dummy_class.release_lock(hosts,
@@ -180,31 +185,35 @@ describe LockingResource::Helper do
       require 'zookeeper' # ugly but easier than mocking the require
       let(:node_path) { '/my_test_path' }
       let(:hosts) { 'localtest_no_host_to_connect:2181' }
-      let(:stat) { double({exists:         true,
-                           ctime:          1476401413663,
-                           mtime:          1476401413663}) }
-      let(:dbl) { double() }
- 
+      let(:stat) do
+        double(exists:         true,
+               ctime:          1_476_401_413_663,
+               mtime:          1_476_401_413_663)
+      end
+      let(:dbl) { double }
+
       it 'returns data if node exists' do
-        expect(Zookeeper).to receive(:new).with(hosts).exactly(1).times{ dbl }
-        expect(dbl).to receive(:connected?).exactly(1).times{ true }
-        expect(dbl).to receive(:stat).with(:path => node_path).\
-          exactly(1).times{ {:rc => 0, :stat => stat} }
-        expect(dbl).to receive(:closed?).exactly(1).times{ false }
+        expect(Zookeeper).to receive(:new).with(hosts).exactly(1).times { dbl }
+        expect(dbl).to receive(:connected?).exactly(1).times { true }
+        expect(dbl).to receive(:stat) \
+          .with(path: node_path) \
+          .exactly(1).times { { rc: 0, stat: stat } }
+        expect(dbl).to receive(:closed?).exactly(1).times { false }
         expect(dbl).to receive(:close).exactly(1).times
-        expect(dummy_class.get_node_ctime(hosts, node_path)).\
-          to match(Time.strptime('1476401413663', '%Q'))
+        expect(dummy_class.get_node_ctime(hosts, node_path)) \
+          .to match(Time.strptime('1476401413663', '%Q'))
       end
 
       it 'returns nil if node can not be read' do
-        expect(Zookeeper).to receive(:new).with(hosts).exactly(1).times{ dbl }
-        expect(dbl).to receive(:connected?).exactly(1).times{ true }
-        expect(dbl).to receive(:stat).with(:path => node_path).\
-          exactly(1).times{ {:rc => -101} }
-        expect(dbl).to receive(:closed?).exactly(1).times{ false }
+        expect(Zookeeper).to receive(:new).with(hosts).exactly(1).times { dbl }
+        expect(dbl).to receive(:connected?).exactly(1).times { true }
+        expect(dbl).to receive(:stat) \
+          .with(path: node_path) \
+          .exactly(1).times { { rc: -101 } }
+        expect(dbl).to receive(:closed?).exactly(1).times { false }
         expect(dbl).to receive(:close).exactly(1).times
-        expect(dummy_class.get_node_ctime(hosts, node_path)).\
-          to match(nil)
+        expect(dummy_class.get_node_ctime(hosts, node_path)) \
+          .to match(nil)
       end
     end
   end
@@ -224,28 +233,30 @@ describe LockingResource::Helper do
       let(:exception_str) do
         "LockingResource: unable to connect to ZooKeeper quorum #{hosts}"
       end
-      let(:dbl) { double() }
+      let(:dbl) { double }
 
       it 'returns data if node exists' do
-        expect(Zookeeper).to receive(:new).with(hosts).exactly(1).times{ dbl }
-        expect(dbl).to receive(:connected?).exactly(1).times{ true }
-        expect(dbl).to receive(:get).with(:path => node_path).\
-          exactly(1).times{ {:rc => 0, :data => my_data} }
-        expect(dbl).to receive(:closed?).exactly(1).times{ false }
+        expect(Zookeeper).to receive(:new).with(hosts).exactly(1).times { dbl }
+        expect(dbl).to receive(:connected?).exactly(1).times { true }
+        expect(dbl).to receive(:get) \
+          .with(path: node_path) \
+          .exactly(1).times { { rc: 0, data: my_data } }
+        expect(dbl).to receive(:closed?).exactly(1).times { false }
         expect(dbl).to receive(:close).exactly(1).times
-        expect(dummy_class.get_node_data(hosts, node_path)).\
-          to match(my_data)
+        expect(dummy_class.get_node_data(hosts, node_path)) \
+          .to match(my_data)
       end
 
       it 'returns nil if node can not be read' do
-        expect(Zookeeper).to receive(:new).with(hosts).exactly(1).times{ dbl }
-        expect(dbl).to receive(:connected?).exactly(1).times{ true }
-        expect(dbl).to receive(:get).with(:path => node_path).\
-          exactly(1).times{ {:rc => -101} }
-        expect(dbl).to receive(:closed?).exactly(1).times{ false }
+        expect(Zookeeper).to receive(:new).with(hosts).exactly(1).times { dbl }
+        expect(dbl).to receive(:connected?).exactly(1).times { true }
+        expect(dbl).to receive(:get) \
+          .with(path: node_path) \
+          .exactly(1).times { { rc: -101 } }
+        expect(dbl).to receive(:closed?).exactly(1).times { false }
         expect(dbl).to receive(:close).exactly(1).times
-        expect(dummy_class.get_node_data(hosts, node_path)).\
-          to match(nil)
+        expect(dummy_class.get_node_data(hosts, node_path)) \
+          .to match(nil)
       end
     end
   end
@@ -260,7 +271,7 @@ describe LockingResource::Helper do
     context 'called without quorum_hosts' do
       it 'raises ArgumentError' do
         expect do
-          dummy_class.run_zk_block(nil){ puts 'Failed if you see this' }
+          dummy_class.run_zk_block(nil) { puts 'Failed if you see this' }
         end.to raise_error(ArgumentError)
       end
     end
@@ -273,64 +284,66 @@ describe LockingResource::Helper do
       let(:exception_str) do
         "LockingResource: unable to connect to ZooKeeper quorum #{hosts}"
       end
-      let(:dbl) { double() }
-    
+      let(:dbl) { double }
+
       it 'calls code in the block and returns value' do
-        expect(Zookeeper).to receive(:new).with(hosts).exactly(1).times{ dbl }
-        expect(dbl).to receive(:connected?).exactly(1).times{ true }
-        expect(dbl).to receive(:closed?).exactly(1).times{ true }
+        expect(Zookeeper).to receive(:new).with(hosts).exactly(1).times { dbl }
+        expect(dbl).to receive(:connected?).exactly(1).times { true }
+        expect(dbl).to receive(:closed?).exactly(1).times { true }
         expect(
-          dummy_class.run_zk_block(hosts){ my_data }
+          dummy_class.run_zk_block(hosts) { my_data }
         ).to eq(my_data)
       end
 
       it 'calls code in the block and returns nil if nothing returned' do
-        expect(Zookeeper).to receive(:new).with(hosts).exactly(1).times{ dbl }
-        expect(dbl).to receive(:connected?).exactly(1).times{ true }
-        expect(dbl).to receive(:closed?).exactly(1).times{ true }
+        expect(Zookeeper).to receive(:new).with(hosts).exactly(1).times { dbl }
+        expect(dbl).to receive(:connected?).exactly(1).times { true }
+        expect(dbl).to receive(:closed?).exactly(1).times { true }
         expect(
-          dummy_class.run_zk_block(hosts){ }
+          dummy_class.run_zk_block(hosts) {}
         ).to eq(nil)
       end
 
       it 'raises if Zk.connect fails' do
-        expect(Zookeeper).to receive(:new).with(hosts).exactly(1).times{ dbl }
-        expect(dbl).to receive(:connected?).exactly(1).times{ false }
-        expect(dbl).to receive(:closed?).exactly(1).times{ false }
+        expect(Zookeeper).to receive(:new).with(hosts).exactly(1).times { dbl }
+        expect(dbl).to receive(:connected?).exactly(1).times { false }
+        expect(dbl).to receive(:closed?).exactly(1).times { false }
         expect(dbl).to receive(:close).exactly(1).times
         expect do
-          dummy_class.run_zk_block(hosts){ puts 'Fail if run' }
+          dummy_class.run_zk_block(hosts) { puts 'Fail if run' }
         end.to raise_error(exception_str)
       end
 
-      it 'raises an exception in the block and Zk.close raising first exception' do
-        expect(Zookeeper).to receive(:new).with(hosts).exactly(1).times{ dbl }
-        expect(dbl).to receive(:connected?).exactly(1).times{ true }
+      it 'raises raises in the block and Zk.close raises first exception' do
+        expect(Zookeeper).to receive(:new).with(hosts).exactly(1).times { dbl }
+        expect(dbl).to receive(:connected?).exactly(1).times { true }
         expect(Chef::Log).to receive(:warn).with('Exception in Block')
-        expect(dbl).to receive(:nil?).exactly(1).times{ false }
-        expect(dbl).to receive(:closed?).exactly(1).times{ false }
-        expect(dbl).to receive(:close).exactly(1).times.and_raise('Exception from close()')
+        expect(dbl).to receive(:nil?).exactly(1).times { false }
+        expect(dbl).to receive(:closed?).exactly(1).times { false }
+        expect(dbl).to receive(:close).exactly(1).times \
+          .and_raise('Exception from close()')
         expect(Chef::Log).to receive(:warn).with('Exception from close()')
         expect do
           dummy_class.run_zk_block(hosts) do
-            raise RuntimeError, 'Exception in Block'
-            'Final return should not be seen'
+            raise 'Exception in Block'
           end
         end.to raise_error(RuntimeError, 'Exception in Block')
       end
 
       it 'swallows an exception in Zk.closed? and returns block result value' do
-        expect(Zookeeper).to receive(:new).with(hosts).exactly(1).times{ dbl }
-        expect(dbl).to receive(:connected?).exactly(1).times{ true }
-        expect(dummy_class).to receive(:lock_matches?).\
-          with(hosts, node_path, my_data).exactly(1).times{ true }
-        expect(dbl).to receive(:delete).exactly(1).times.\
-          with(:path => node_path){ {"rc".to_sym => 0} }
-        expect(dbl).to receive(:closed?).exactly(1).times.\
-          and_raise(exception_str)
+        expect(Zookeeper).to receive(:new).with(hosts).exactly(1).times { dbl }
+        expect(dbl).to receive(:connected?).exactly(1).times { true }
+        expect(dummy_class).to receive(:lock_matches?) \
+          .with(hosts, node_path, my_data).exactly(1).times { true }
+        expect(dbl).to receive(:delete) \
+          .exactly(1).times \
+          .with(path: node_path) { { 'rc'.to_sym => 0 } }
+        expect(dbl).to receive(:closed?) \
+          .exactly(1).times \
+          .and_raise(exception_str)
         expect(Chef::Log).to receive(:warn).with(exception_str)
         expect(dummy_class.release_lock(hosts, node_path,
-          my_data)).to match(true)
+                                        my_data)).to match(true)
       end
     end
   end
@@ -351,25 +364,26 @@ describe LockingResource::Helper do
 
       def return_stdout(arg)
         # return a PID for pgrep(1)
-        return pgrep_output if arg.strip() == %Q{pgrep -o -f "#{test_command}"}
+        return pgrep_output if arg.strip == %(pgrep -o -f "#{test_command}")
         # We must return a known date
         return "#{ps_output}\n" if arg.start_with?('ps')
         raise "Unexpected arg: |#{arg}|"
       end
- 
+
       it 'raises under pgrep error' do
-        expect(Mixlib::ShellOut).to receive(:new) do |arg|
-          double({ run_command: nil,
-            error!: '',
-            exitstatus: 0,
-            stdout: '',
-            stderr: error_string,
-            live_stream: ''
-          })
+        expect(Mixlib::ShellOut).to receive(:new) do
+          double(run_command: nil,
+                 error!: '',
+                 exitstatus: 0,
+                 stdout: '',
+                 stderr: error_string,
+                 live_stream: ''
+                )
         end.exactly(1).times
-        expect { dummy_class.new.process_start_time(full_cmd: true,
-          command_string: test_command) }.to \
-          raise_error(error_string)
+        expect do
+          dummy_class.new.process_start_time(full_cmd: true,
+                                             command_string: test_command)
+        end.to raise_error(error_string)
       end
 
 # Can not seem to get standard out stub to work
@@ -379,14 +393,14 @@ describe LockingResource::Helper do
 #  #process_start_time?
 #    process exists
 #XXX early_idx 0; PIDs: [29371, 6114]
-#XXX3 Happy run - earliest time!  
+#XXX3 Happy run - earliest time!
 #XXX early_idx 0; PIDs: [29371, 6114]
 #XXX0 return_stdout Arg: pgrep -f "my command"
 #XXX1 pgrep output: 29371
 #6114
 #XXXlib pgrep , XXX 29371
 #6114
-#XXX3 Happy run - earliest time!  
+#XXX3 Happy run - earliest time!
 #XXX early_idx 0; PIDs: [29371, 6114]
 #XXX0 return_stdout Arg: ps --no-header -o lstart 29371
 #XXX1 Returning early
@@ -448,17 +462,17 @@ describe LockingResource::Helper do
 
       it 'returns the earliest time' do
         expect(Mixlib::ShellOut).to receive(:new) do |arg|
-          double({ run_command: nil,
-            error!: '',
-            exitstatus: 0,
-            stdout: return_stdout(arg),
-            stderr: '',
-            live_stream: ''
-          })
+          double(run_command: nil,
+                 error!: '',
+                 exitstatus: 0,
+                 stdout: return_stdout(arg),
+                 stderr: '',
+                 live_stream: ''
+                )
         end.exactly(2).times
-        expect(dummy_class.new.process_start_time(full_cmd: true,
-          command_string: test_command).to_i).to \
-          eq(Time.parse(ps_output).to_i)
+        expect(dummy_class.new.process_start_time(
+          full_cmd: true, command_string: test_command).to_i).to \
+            eq(Time.parse(ps_output).to_i)
       end
     end
   end
@@ -477,44 +491,44 @@ describe LockingResource::Helper do
     context 'test node has had reruns set' do
       let(:node) { Chef::Node.new }
       let(:mock_time) { Time.strptime('1476401413663', '%Q') }
-      let(:path1_rerun_data) { { "time" => mock_time - 10*60, "fails" => 1 } } 
-      let(:path2_rerun_data) { { "time" => mock_time - 30*60, "fails" => 1 } } 
+      let(:path1_rerun_data) { { 'time' => mock_time - 10 * 60, 'fails' => 1 } }
+      let(:path2_rerun_data) { { 'time' => mock_time - 30 * 60, 'fails' => 1 } }
       let(:path1) { 'cookbook::recipe::test_package' }
       let(:path2) { 'cookbook::recipe::test_bash' }
       before(:each) do
-        node.normal[:locking_resource][:failed_locks] = {
+        node.normal['locking_resource']['failed_locks'] = {
           path1 => path1_rerun_data,
           path2 => path2_rerun_data
         }
       end
 
-      it '#clear_rerun(path1) returns mock_time - 10*60' do
+      it '#clear_rerun(path1) returns mock_time - 10 * 60' do
         expect(dummy_class.new.clear_rerun(node, path1)).to \
           match_array(path1_rerun_data)
       end
 
-      it '#rerun_time?(path2) returns mock_time - 30*60' do
+      it '#rerun_time?(path2) returns mock_time - 30 * 60' do
         expect(dummy_class.new.rerun_time?(node, path2)).to \
-          eq(mock_time - 30*60)
+          eq(mock_time - 30 * 60)
       end
 
-      it '#need_rerun(path1) returns mock_time - 10*60' do
+      it '#need_rerun(path1) returns mock_time - 10 * 60' do
         allow(Time).to receive(:now).and_return(mock_time)
         expect(dummy_class.new.need_rerun(node, path1)).to \
-          match_array({ "time" => path1_rerun_data["time"],
-                        "fails" => path1_rerun_data["fails"] + 1 })
+          match_array('time' => path1_rerun_data['time'],
+                      'fails' => path1_rerun_data['fails'] + 1)
       end
     end
 
     context 'test node has not had a rerun set' do
       let(:node) { Chef::Node.new }
       before(:each) do
-        node.normal[:locking_resource][:failed_locks] = {}
+        node.normal['locking_resource']['failed_locks'] = {}
       end
       let(:path1) { 'cookbook::recipe::test_package' }
       let(:path2) { 'cookbook::recipe::test_bash' }
       let(:mock_time) { Time.strptime('1476401413663', '%Q') }
-      let(:rerun_data) { { "time" => mock_time, "fails" => 1 } } 
+      let(:rerun_data) { { 'time' => mock_time, 'fails' => 1 } }
 
       it '#clear_rerun returns nil' do
         expect(dummy_class.new.clear_rerun(node, path1)).to eq(nil)

--- a/test/cookbooks/locking_resource_test/metadata.rb
+++ b/test/cookbooks/locking_resource_test/metadata.rb
@@ -6,5 +6,5 @@ description      'Installs and configures locking_resource cookbook for testing'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.0'
 
-depends 'zookeeper', '=6.0.0'
+depends 'zookeeper', '>= 8.1.4'
 depends 'locking_resource'

--- a/test/cookbooks/locking_resource_test/recipes/default.rb
+++ b/test/cookbooks/locking_resource_test/recipes/default.rb
@@ -2,12 +2,12 @@ include_recipe 'zookeeper::default'
 include_recipe 'zookeeper::service'
 include_recipe 'locking_resource::default'
 
-log "This is a dummy resource" do
+log 'This is a dummy resource' do
   action :nothing
 end
 
-locking_resource "Dummy Resource Lock" do
-  resource "log[This is a dummy resource]"
+locking_resource 'Dummy Resource Lock' do
+  resource 'log[This is a dummy resource]'
   action :serialize
   perform :write
 end

--- a/test/cookbooks/locking_resource_test/recipes/default.rb
+++ b/test/cookbooks/locking_resource_test/recipes/default.rb
@@ -1,6 +1,4 @@
-node.default['zookeeper']['service_style'] = 'runit'
 include_recipe 'zookeeper::default'
-include_recipe 'runit'
 include_recipe 'zookeeper::service'
 include_recipe 'locking_resource::default'
 

--- a/test/cookbooks/locking_resource_test/recipes/exception_serialized_lock.rb
+++ b/test/cookbooks/locking_resource_test/recipes/exception_serialized_lock.rb
@@ -11,23 +11,24 @@ Chef::Resource::RubyBlock.send(:include, LockingResource::Helper)
 #
 
 lock_resource = 'Dummy Resource Lock'
-lock_path = ::File.join(node[:locking_resource][:restart_lock][:root],
-                        "ruby_block[#{lock_resource.gsub(' ', ':')}]")
-zk_hosts = parse_zk_hosts(node[:locking_resource][:zookeeper_servers])
+lock_path = ::File.join(node['locking_resource']['restart_lock']['root'],
+                        "ruby_block[#{lock_resource.tr(' ', ':')}]")
+zk_hosts = parse_zk_hosts(node['locking_resource']['zookeeper_servers'])
 node.run_state['times'] = {}
 
 # Create the resource for us to serialize
 ruby_block lock_resource do
   block do
     node.run_state['times'][lock_resource] = Time.now
-    Chef::Log.warn "Dummy resource ran at: #{node.run_state['times'][lock_resource]}"
-    raise "Failing to ensure lock sticks around..."
+    Chef::Log.warn 'Dummy resource ran at: ' \
+      "#{node.run_state['times'][lock_resource]}"
+    raise 'Failing to ensure lock sticks around...'
   end
   action :nothing
 end
 
 log 'Initial Time' do
-  message lazy{"The time starting is now: #{Time.now}"}
+  message lazy { "The time starting is now: #{Time.now}" }
   notifies :run, 'ruby_block[Verify Lock Still Held]', :delayed
 end
 
@@ -37,9 +38,11 @@ ruby_block 'Verify Lock Still Held' do
     res_run_time = node.run_state['times'][lock_resource]
     now = Time.now
     Chef::Log.warn "The time after locking resource: #{now}"
-    raise "Locked resource has not run before this! (#{res_run_time} < #{now})" unless res_run_time < now
-    raise "Not holding lock!" unless lock_matches?(zk_hosts, lock_path, node[:fqdn])
-    Chef::Log.warn("ALL CHECKS PASSED!")
+    raise 'Locked resource has not run before this!' \
+      "(#{res_run_time} < #{now})" unless res_run_time < now
+    raise 'Not holding lock!' unless \
+      lock_matches?(zk_hosts, lock_path, node['fqdn'])
+    Chef::Log.warn('ALL CHECKS PASSED!')
 
     # Since we are verifying the Chef run failed exit!(0) to bail with a zero
     # exit status -- we should be blocked by raise()'s above -- this is ugly

--- a/test/cookbooks/locking_resource_test/recipes/exception_serialized_lock.rb
+++ b/test/cookbooks/locking_resource_test/recipes/exception_serialized_lock.rb
@@ -38,8 +38,10 @@ ruby_block 'Verify Lock Still Held' do
     res_run_time = node.run_state['times'][lock_resource]
     now = Time.now
     Chef::Log.warn "The time after locking resource: #{now}"
-    raise 'Locked resource has not run before this!' \
-      "(#{res_run_time} < #{now})" unless res_run_time < now
+    unless res_run_time < now
+      raise 'Locked resource has not run before this!' \
+         "(#{res_run_time} < #{now})"
+    end
     raise 'Not holding lock!' unless \
       lock_matches?(zk_hosts, lock_path, node['fqdn'])
     Chef::Log.warn('ALL CHECKS PASSED!')

--- a/test/cookbooks/locking_resource_test/recipes/held_serialized_lock.rb
+++ b/test/cookbooks/locking_resource_test/recipes/held_serialized_lock.rb
@@ -1,6 +1,4 @@
-node.default['zookeeper']['service_style'] = 'runit'
 include_recipe 'zookeeper::default'
-include_recipe 'runit'
 include_recipe 'zookeeper::service'
 include_recipe 'locking_resource::default'
 Chef::Recipe.send(:include, LockingResource::Helper)

--- a/test/cookbooks/locking_resource_test/recipes/held_serialized_lock.rb
+++ b/test/cookbooks/locking_resource_test/recipes/held_serialized_lock.rb
@@ -110,17 +110,19 @@ end
 ruby_block 'verify timings' do
   block do
     # verify the Chef run progressed while we waited to release the lock
-    raise('Chef run should have continued ' \
-      "(#{node.run_state['times']['before_locking_resource']}) before lock " \
-      "release thread awoke (#{node.run_state['times']['unwind_wake_time']})") \
-      if node.run_state['times']['before_locking_resource'].to_f > \
-         node.run_state['times']['unwind_wake_time'].to_f
+    if node.run_state['times']['before_locking_resource'].to_f > \
+       node.run_state['times']['unwind_wake_time'].to_f
+      raise('Chef run should have continued ' \
+        "(#{node.run_state['times']['before_locking_resource']}) before lock " \
+        "release thread awoke (#{node.run_state['times']['unwind_wake_time']})")
+    end
 
     # verify the serialized resource only ran after the lock was released
-    raise('Locking resource should run ' \
-      "(#{node.run_state['times'][lock_resource]}) only after we unwind the" \
-      " colliding lock (#{node.run_state['times']['unwind_wake_time']})") \
-      if node.run_state['times']['unwind_wake_time'].to_f > \
-         node.run_state['times'][lock_resource].to_f
+    if node.run_state['times']['unwind_wake_time'].to_f > \
+       node.run_state['times'][lock_resource].to_f
+      raise('Locking resource should run ' \
+        "(#{node.run_state['times'][lock_resource]}) only after we unwind the" \
+        " colliding lock (#{node.run_state['times']['unwind_wake_time']})")
+    end
   end
 end

--- a/test/cookbooks/locking_resource_test/recipes/re_run_lock_newer.rb
+++ b/test/cookbooks/locking_resource_test/recipes/re_run_lock_newer.rb
@@ -1,0 +1,48 @@
+include_recipe 'zookeeper::default'
+include_recipe 'zookeeper::service'
+include_recipe 'locking_resource::default'
+include_recipe 'locking_resource_test::re_run_lock_setup'
+Chef::Recipe.send(:include, LockingResource::Helper)
+Chef::Resource::RubyBlock.send(:include, LockingResource::Helper)
+
+###
+# This recipe is designed to run after re_run_lock_setup has created state
+# for resource failure
+# * Run a serialized process action with newer process running
+#   (should not execute -- but should clean-up state)
+#
+
+lock_resource = 'Dummy Resource One'
+lock_path = "ruby_block[#{lock_resource.gsub(' ', ':')}]"
+full_lock_path = ::File.join(node[:locking_resource][:restart_lock][:root],
+                             lock_path)
+test_process = '/bin/sleep 60'                                                  
+                                                                                
+ruby_block 'Run a test process' do                                              
+  block do                                                                      
+    # make sure we wait long enough that at a one second granularity the        
+    # state times and process start times are different                         
+    sleep(2)                                                                    
+    node.run_state[:child_pid] = spawn(test_process)                            
+  end                                                                           
+end  
+
+locking_resource 'Clean-up state (and not run) if process newer than lock' do
+  lock_name lock_path
+  resource "ruby_block[#{lock_resource}]"
+  process_pattern do
+    command_string test_process
+    full_cmd true
+  end
+  action :serialize_process
+  perform :run
+end
+
+ruby_block 'Check action not run and re-run state was cleaned up' do
+  block do
+    raise 'Ran action and should not have!' if \
+      node.run_state[:locking_resource_test][:ran_action]
+    re_run_state = node[:locking_resource][:failed_locks][full_lock_path]
+    raise "Re-run state not cleaned up: #{re_run_state}" if re_run_state
+  end
+end

--- a/test/cookbooks/locking_resource_test/recipes/re_run_lock_newer.rb
+++ b/test/cookbooks/locking_resource_test/recipes/re_run_lock_newer.rb
@@ -13,19 +13,19 @@ Chef::Resource::RubyBlock.send(:include, LockingResource::Helper)
 #
 
 lock_resource = 'Dummy Resource One'
-lock_path = "ruby_block[#{lock_resource.gsub(' ', ':')}]"
-full_lock_path = ::File.join(node[:locking_resource][:restart_lock][:root],
+lock_path = "ruby_block[#{lock_resource.tr(' ', ':')}]"
+full_lock_path = ::File.join(node['locking_resource']['restart_lock']['root'],
                              lock_path)
-test_process = '/bin/sleep 60'                                                  
-                                                                                
-ruby_block 'Run a test process' do                                              
-  block do                                                                      
-    # make sure we wait long enough that at a one second granularity the        
-    # state times and process start times are different                         
-    sleep(2)                                                                    
-    node.run_state[:child_pid] = spawn(test_process)                            
-  end                                                                           
-end  
+test_process = '/bin/sleep 60'
+
+ruby_block 'Run a test process' do
+  block do
+    # make sure we wait long enough that at a one second granularity the
+    # state times and process start times are different
+    sleep(2)
+    node.run_state['child_pid'] = spawn(test_process)
+  end
+end
 
 locking_resource 'Clean-up state (and not run) if process newer than lock' do
   lock_name lock_path
@@ -41,8 +41,8 @@ end
 ruby_block 'Check action not run and re-run state was cleaned up' do
   block do
     raise 'Ran action and should not have!' if \
-      node.run_state[:locking_resource_test][:ran_action]
-    re_run_state = node[:locking_resource][:failed_locks][full_lock_path]
+      node.run_state['locking_resource_test']['ran_action']
+    re_run_state = node['locking_resource']['failed_locks'][full_lock_path]
     raise "Re-run state not cleaned up: #{re_run_state}" if re_run_state
   end
 end

--- a/test/cookbooks/locking_resource_test/recipes/re_run_lock_older.rb
+++ b/test/cookbooks/locking_resource_test/recipes/re_run_lock_older.rb
@@ -5,15 +5,15 @@ include_recipe 'locking_resource_test::re_run_lock_setup'
 Chef::Recipe.send(:include, LockingResource::Helper)
 Chef::Resource::RubyBlock.send(:include, LockingResource::Helper)
 
-####                                                                             
-## This recipe is designed to run after re_run_lock_setup has created state      
-## for resource failure                                                          
-## * Run a serialized process action with old process running (should execute)       
-##  
+####
+## This recipe is designed to run after re_run_lock_setup has created state
+## for resource failure
+## * Run a serialized process action with old process running (should execute)
+##
 
 lock_resource = 'Dummy Resource One'
-lock_path = "ruby_block[#{lock_resource.gsub(' ', ':')}]"
-full_lock_path = ::File.join(node[:locking_resource][:restart_lock][:root],
+lock_path = "ruby_block[#{lock_resource.tr(' ', ':')}]"
+full_lock_path = ::File.join(node['locking_resource']['restart_lock']['root'],
                              lock_path)
 
 locking_resource 'We run if process older than first attempt' do
@@ -30,8 +30,8 @@ end
 ruby_block 'Check re-run state was cleaned up' do
   block do
     raise 'Did not run action!' unless \
-      node.run_state[:locking_resource_test][:ran_action]
-    re_run_state = node[:locking_resource][:failed_locks][full_lock_path]
+      node.run_state['locking_resource_test']['ran_action']
+    re_run_state = node['locking_resource']['failed_locks'][full_lock_path]
     raise "Re-run state not cleaned up: #{re_run_state}" if re_run_state
   end
 end

--- a/test/cookbooks/locking_resource_test/recipes/re_run_lock_older.rb
+++ b/test/cookbooks/locking_resource_test/recipes/re_run_lock_older.rb
@@ -1,0 +1,37 @@
+include_recipe 'zookeeper::default'
+include_recipe 'zookeeper::service'
+include_recipe 'locking_resource::default'
+include_recipe 'locking_resource_test::re_run_lock_setup'
+Chef::Recipe.send(:include, LockingResource::Helper)
+Chef::Resource::RubyBlock.send(:include, LockingResource::Helper)
+
+####                                                                             
+## This recipe is designed to run after re_run_lock_setup has created state      
+## for resource failure                                                          
+## * Run a serialized process action with old process running (should execute)       
+##  
+
+lock_resource = 'Dummy Resource One'
+lock_path = "ruby_block[#{lock_resource.gsub(' ', ':')}]"
+full_lock_path = ::File.join(node[:locking_resource][:restart_lock][:root],
+                             lock_path)
+
+locking_resource 'We run if process older than first attempt' do
+  lock_name lock_path
+  resource "ruby_block[#{lock_resource}]"
+  process_pattern do
+    command_string 'init'
+    user 'root'
+  end
+  action :serialize_process
+  perform :run
+end
+
+ruby_block 'Check re-run state was cleaned up' do
+  block do
+    raise 'Did not run action!' unless \
+      node.run_state[:locking_resource_test][:ran_action]
+    re_run_state = node[:locking_resource][:failed_locks][full_lock_path]
+    raise "Re-run state not cleaned up: #{re_run_state}" if re_run_state
+  end
+end

--- a/test/cookbooks/locking_resource_test/recipes/re_run_lock_setup.rb
+++ b/test/cookbooks/locking_resource_test/recipes/re_run_lock_setup.rb
@@ -1,0 +1,93 @@
+include_recipe 'zookeeper::default'
+include_recipe 'zookeeper::service'
+include_recipe 'locking_resource::default'
+Chef::Recipe.send(:include, LockingResource::Helper)
+Chef::Resource::RubyBlock.send(:include, LockingResource::Helper)
+
+
+###
+# This recipe is designed to create a held lock and ensure we
+# don't run due to the lock (used by recipes to test handling once
+# lock released). Process:
+# * Create conflicting lock
+# * Run a serialized process action (should timeout)
+# * Run a serialized process action (should timeout again)
+# * Clear conflicting lock
+#
+
+# Reset failed_locks
+node.normal[:locking_resource][:failed_locks] = {}
+
+zk_hosts = parse_zk_hosts(node[:locking_resource][:zookeeper_servers])
+lock_resource = 'Dummy Resource One'
+lock_path = "ruby_block[#{lock_resource.gsub(' ', ':')}]"
+full_lock_path = ::File.join(node[:locking_resource][:restart_lock][:root],
+                             lock_path)
+node.run_state[:locking_resource_test] = {}
+node.run_state[:locking_resource_test][:ran_action] = false
+
+# Create the resources for us to serialize
+ruby_block lock_resource do
+  block do
+    Chef::Log.warn "Dummy resource -- which should run -- ran at: #{Time.now}"
+    node.run_state[:locking_resource_test][:ran_action] = true
+  end
+  action :nothing
+end
+
+ruby_block 'Create a blocking lock' do
+  block do
+    got_lock = create_node(zk_hosts, full_lock_path, 'foobar') and \
+        Chef::Log.warn "#{Time.now}: Acquired blocking lock"
+    raise 'Did not set lock' unless lock_matches?(zk_hosts, full_lock_path,
+                                                  'foobar')
+  end
+end
+
+# Try to run a serialized action -- timeout
+locking_resource 'Test we do not run with held lock -- should timeout' do
+  lock_name lock_path
+  resource "ruby_block[#{lock_resource}]"
+  perform :run
+  action :serialize
+  ignore_failure true
+end
+
+ruby_block 'Verify rerun state set' do
+  block do
+    raise 'Some how already ran' if \
+      node.run_state[:locking_resource_test][:ran_action]
+    re_run_parent = node[:locking_resource][:failed_locks]
+    raise "Re-run state not set #{re_run_parent}" unless \
+      re_run_parent.has_key?(full_lock_path)
+  end
+end
+
+# Still should not run the serialized action -- but verify we increment state
+# and ensure we don't run without the lock
+locking_resource 'ruby_block -- timeout again' do
+  lock_name lock_path
+  resource "ruby_block[#{lock_resource}]"
+  perform :run
+  action :serialize
+  ignore_failure true
+end
+
+ruby_block 'Verify rerun failures incremented' do
+  block do
+    raise 'Some how already ran' if \
+      node.run_state[:locking_resource_test][:ran_action]
+    fails = node[:locking_resource][:failed_locks][full_lock_path]['fails']
+    raise "Re-run state not incremented: #{fails}" unless fails == 2
+  end
+end
+
+ruby_block 'Clean-up the stale lock' do
+  block do
+    raise 'Some how already ran' if \
+      node.run_state[:locking_resource_test][:ran_action]
+    release_lock(zk_hosts, full_lock_path, 'foobar')
+    raise 'Did not release lock' if lock_matches?(zk_hosts, full_lock_path,
+                                                  'foobar')
+  end
+end

--- a/test/cookbooks/locking_resource_test/recipes/re_run_lock_setup.rb
+++ b/test/cookbooks/locking_resource_test/recipes/re_run_lock_setup.rb
@@ -4,7 +4,6 @@ include_recipe 'locking_resource::default'
 Chef::Recipe.send(:include, LockingResource::Helper)
 Chef::Resource::RubyBlock.send(:include, LockingResource::Helper)
 
-
 ###
 # This recipe is designed to create a held lock and ensure we
 # don't run due to the lock (used by recipes to test handling once
@@ -16,29 +15,29 @@ Chef::Resource::RubyBlock.send(:include, LockingResource::Helper)
 #
 
 # Reset failed_locks
-node.normal[:locking_resource][:failed_locks] = {}
+node.normal['locking_resource']['failed_locks'] = {}
 
-zk_hosts = parse_zk_hosts(node[:locking_resource][:zookeeper_servers])
+zk_hosts = parse_zk_hosts(node['locking_resource']['zookeeper_servers'])
 lock_resource = 'Dummy Resource One'
-lock_path = "ruby_block[#{lock_resource.gsub(' ', ':')}]"
-full_lock_path = ::File.join(node[:locking_resource][:restart_lock][:root],
+lock_path = "ruby_block[#{lock_resource.tr(' ', ':')}]"
+full_lock_path = ::File.join(node['locking_resource']['restart_lock']['root'],
                              lock_path)
-node.run_state[:locking_resource_test] = {}
-node.run_state[:locking_resource_test][:ran_action] = false
+node.run_state['locking_resource_test'] = {}
+node.run_state['locking_resource_test']['ran_action'] = false
 
 # Create the resources for us to serialize
 ruby_block lock_resource do
   block do
     Chef::Log.warn "Dummy resource -- which should run -- ran at: #{Time.now}"
-    node.run_state[:locking_resource_test][:ran_action] = true
+    node.run_state['locking_resource_test']['ran_action'] = true
   end
   action :nothing
 end
 
 ruby_block 'Create a blocking lock' do
   block do
-    got_lock = create_node(zk_hosts, full_lock_path, 'foobar') and \
-        Chef::Log.warn "#{Time.now}: Acquired blocking lock"
+    create_node(zk_hosts, full_lock_path, 'foobar') and \
+      Chef::Log.warn "#{Time.now}: Acquired blocking lock"
     raise 'Did not set lock' unless lock_matches?(zk_hosts, full_lock_path,
                                                   'foobar')
   end
@@ -56,10 +55,10 @@ end
 ruby_block 'Verify rerun state set' do
   block do
     raise 'Some how already ran' if \
-      node.run_state[:locking_resource_test][:ran_action]
-    re_run_parent = node[:locking_resource][:failed_locks]
+      node.run_state['locking_resource_test']['ran_action']
+    re_run_parent = node['locking_resource']['failed_locks']
     raise "Re-run state not set #{re_run_parent}" unless \
-      re_run_parent.has_key?(full_lock_path)
+      re_run_parent.key?(full_lock_path)
   end
 end
 
@@ -76,8 +75,8 @@ end
 ruby_block 'Verify rerun failures incremented' do
   block do
     raise 'Some how already ran' if \
-      node.run_state[:locking_resource_test][:ran_action]
-    fails = node[:locking_resource][:failed_locks][full_lock_path]['fails']
+      node.run_state['locking_resource_test']['ran_action']
+    fails = node['locking_resource']['failed_locks'][full_lock_path]['fails']
     raise "Re-run state not incremented: #{fails}" unless fails == 2
   end
 end
@@ -85,7 +84,7 @@ end
 ruby_block 'Clean-up the stale lock' do
   block do
     raise 'Some how already ran' if \
-      node.run_state[:locking_resource_test][:ran_action]
+      node.run_state['locking_resource_test']['ran_action']
     release_lock(zk_hosts, full_lock_path, 'foobar')
     raise 'Did not release lock' if lock_matches?(zk_hosts, full_lock_path,
                                                   'foobar')

--- a/test/cookbooks/locking_resource_test/recipes/serialized_process_lock_handling.rb
+++ b/test/cookbooks/locking_resource_test/recipes/serialized_process_lock_handling.rb
@@ -1,6 +1,4 @@
-node.default['zookeeper']['service_style'] = 'runit'
 include_recipe 'zookeeper::default'
-include_recipe 'runit'
 include_recipe 'zookeeper::service'
 include_recipe 'locking_resource::default'
 Chef::Recipe.send(:include, LockingResource::Helper)

--- a/test/cookbooks/locking_resource_test/recipes/serialized_process_lock_handling.rb
+++ b/test/cookbooks/locking_resource_test/recipes/serialized_process_lock_handling.rb
@@ -42,8 +42,10 @@ end
 # Create a stale lock
 ruby_block 'Create a stale lock for init process' do
   block do
+    # rubocop:disable Style/AndOr
     create_node(zk_hosts, lock_path1, node['fqdn']) and \
       Chef::Log.warn "#{Time.now}: Acquired stale lock"
+    # rubocop:enable Style/AndOr
     raise 'Did not set lock' unless lock_matches?(zk_hosts, lock_path1,
                                                   node['fqdn'])
   end
@@ -74,8 +76,10 @@ end
 # Create a stale lock and run a process after
 ruby_block 'Create a stale lock and run a command' do
   block do
+    # rubocop:disable Style/AndOr
     create_node(zk_hosts, lock_path2, node['fqdn']) and \
       Chef::Log.warn "#{Time.now}: Acquired stale lock"
+    # rubocop:enable Style/AndOr
     raise 'Did not set lock' unless lock_matches?(zk_hosts, lock_path2,
                                                   node['fqdn'])
     # make sure we wait long enough that at a one second granularity the znode

--- a/test/cookbooks/locking_resource_test/recipes/serialized_process_lock_handling.rb
+++ b/test/cookbooks/locking_resource_test/recipes/serialized_process_lock_handling.rb
@@ -9,31 +9,32 @@ Chef::Resource::RubyBlock.send(:include, LockingResource::Helper)
 # re-run due to the lock
 #
 
-zk_hosts = parse_zk_hosts(node[:locking_resource][:zookeeper_servers])
+zk_hosts = parse_zk_hosts(node['locking_resource']['zookeeper_servers'])
 lock_resource1 = 'Dummy Resource One'
 lock_resource2 = 'Dummy Resource Two'
-lock_path1 = ::File.join(node[:locking_resource][:restart_lock][:root],
-                        "ruby_block[#{lock_resource1.gsub(' ', ':')}]")
-lock_path2 = ::File.join(node[:locking_resource][:restart_lock][:root],
-                        "ruby_block[#{lock_resource2.gsub(' ', ':')}]")
-node.run_state[:locking_resource] = {}
-node.run_state[:locking_resource][:ran_action] = []
-node.run_state[:locking_resource][:ran_action][1] = false
-node.run_state[:locking_resource][:ran_action][2] = false
+lock_path1 = ::File.join(node['locking_resource']['restart_lock']['root'],
+                         "ruby_block[#{lock_resource1.tr(' ', ':')}]")
+lock_path2 = ::File.join(node['locking_resource']['restart_lock']['root'],
+                         "ruby_block[#{lock_resource2.tr(' ', ':')}]")
+node.run_state['locking_resource'] = {}
+node.run_state['locking_resource']['ran_action'] = []
+node.run_state['locking_resource']['ran_action'][1] = false
+node.run_state['locking_resource']['ran_action'][2] = false
 
 # Create the resources for us to serialize
 ruby_block lock_resource1 do
   block do
     Chef::Log.warn "Dummy resource -- which should run -- ran at: #{Time.now}"
-    node.run_state[:locking_resource][:ran_action][1] = true
+    node.run_state['locking_resource']['ran_action'][1] = true
   end
   action :nothing
 end
 
 ruby_block lock_resource2 do
   block do
-    Chef::Log.warn "Dummy resource -- which should not run -- ran at: #{Time.now}"
-    node.run_state[:locking_resource][:ran_action][2] = true
+    Chef::Log.warn 'Dummy resource -- which should not run -- ' \
+                   "ran at: #{Time.now}"
+    node.run_state['locking_resource']['ran_action'][2] = true
   end
   action :nothing
 end
@@ -41,18 +42,20 @@ end
 # Create a stale lock
 ruby_block 'Create a stale lock for init process' do
   block do
-    got_lock = create_node(zk_hosts, lock_path1, node[:fqdn]) and \
-        Chef::Log.warn "#{Time.now}: Acquired stale lock"
-    raise "Did not set lock" unless lock_matches?(zk_hosts, lock_path1,
-                                                  node[:fqdn])
+    create_node(zk_hosts, lock_path1, node['fqdn']) and \
+      Chef::Log.warn "#{Time.now}: Acquired stale lock"
+    raise 'Did not set lock' unless lock_matches?(zk_hosts, lock_path1,
+                                                  node['fqdn'])
   end
 end
 
 # Try to run a serialized action
 locking_resource "ruby_block[#{lock_resource1}]" do
   resource "ruby_block[#{lock_resource1}]"
-  process_pattern {command_string 'init'
-                   user 'root'}
+  process_pattern do
+    command_string 'init'
+    user 'root'
+  end
   perform :run
   action :serialize_process
 end
@@ -61,33 +64,35 @@ end
 ruby_block 'verify lock cleaned-up for init process' do
   block do
     raise 'Did not clean-up lock' if lock_matches?(zk_hosts, lock_path1,
-                                                   node[:fqdn])
+                                                   node['fqdn'])
     # verify the Chef ran the action
     raise("Chef did not run ruby_block[#{lock_resource}]") unless
-      node.run_state[:locking_resource][:ran_action][1]
+      node.run_state['locking_resource']['ran_action'][1]
   end
 end
 
 # Create a stale lock and run a process after
 ruby_block 'Create a stale lock and run a command' do
   block do
-    got_lock = create_node(zk_hosts, lock_path2, node[:fqdn]) and \
-        Chef::Log.warn "#{Time.now}: Acquired stale lock"
-    raise "Did not set lock" unless lock_matches?(zk_hosts, lock_path2,
-                                                  node[:fqdn])
+    create_node(zk_hosts, lock_path2, node['fqdn']) and \
+      Chef::Log.warn "#{Time.now}: Acquired stale lock"
+    raise 'Did not set lock' unless lock_matches?(zk_hosts, lock_path2,
+                                                  node['fqdn'])
     # make sure we wait long enough that at a one second granularity the znode
     # and process start times are different
     sleep(2)
-    node.run_state[:child_pid] = spawn("/bin/sleep 60")
+    node.run_state['child_pid'] = spawn('/bin/sleep 60')
   end
 end
 
 # Try to run a serialized action
 locking_resource "ruby_block[#{lock_resource2}]" do
   resource "ruby_block[#{lock_resource2}]"
-  process_pattern {command_string 'sleep 60'
-                   user Process.uid.to_s
-                   full_cmd true}
+  process_pattern do
+    command_string 'sleep 60'
+    user Process.uid.to_s
+    full_cmd true
+  end
   perform :run
   action :serialize_process
 end
@@ -96,11 +101,11 @@ end
 ruby_block 'verify lock cleaned-up for recently run command' do
   block do
     raise 'Did not clean-up lock' if lock_matches?(zk_hosts, lock_path2,
-                                              node[:fqdn])
+                                                   node['fqdn'])
     # verify the Chef ran the action
     raise("Chef ran ruby_block[#{lock_resource2}]") if
-      node.run_state[:locking_resource][:ran_action][2]
+      node.run_state['locking_resource']['ran_action'][2]
 
-    Process.kill("TERM", node.run_state[:child_pid])
+    Process.kill('TERM', node.run_state['child_pid'])
   end
 end

--- a/test/cookbooks/locking_resource_test/recipes/simple_serialized_lock.rb
+++ b/test/cookbooks/locking_resource_test/recipes/simple_serialized_lock.rb
@@ -1,6 +1,4 @@
-node.default['zookeeper']['service_style'] = 'runit'
 include_recipe 'zookeeper::default'
-include_recipe 'runit'
 include_recipe 'zookeeper::service'
 include_recipe 'locking_resource::default'
 

--- a/test/cookbooks/locking_resource_test/recipes/simple_serialized_process.rb
+++ b/test/cookbooks/locking_resource_test/recipes/simple_serialized_process.rb
@@ -2,13 +2,13 @@ include_recipe 'zookeeper::default'
 include_recipe 'zookeeper::service'
 include_recipe 'locking_resource::default'
 
-lock_resource = "my resource"
-node.run_state[:ran_action] = false
+lock_resource = 'my resource'
+node.run_state['ran_action'] = false
 
 ruby_block lock_resource do
   block do
-    Chef::Log.warn "Dummy resource -- which should run"
-    node.run_state[:ran_action] = true
+    Chef::Log.warn 'Dummy resource -- which should run'
+    node.run_state['ran_action'] = true
   end
   action :nothing
 end
@@ -16,17 +16,17 @@ end
 locking_resource 'Test we run if process dead' do
   resource "ruby_block[#{lock_resource}]"
   process_pattern do
-    command_string "not a command" 
+    command_string 'not a command'
   end
   action :serialize_process
   perform :run
 end
 
-# Make sure we actually logged 
+# Make sure we actually logged
 ruby_block 'verify dummy resource actually ran' do
   block do
     # verify the Chef ran the action
     raise("Chef was supposed to run ruby_block[#{lock_resource}]") unless
-      node.run_state[:ran_action]
+      node.run_state['ran_action']
   end
 end

--- a/test/cookbooks/locking_resource_test/recipes/simple_serialized_process.rb
+++ b/test/cookbooks/locking_resource_test/recipes/simple_serialized_process.rb
@@ -1,6 +1,4 @@
-node.default['zookeeper']['service_style'] = 'runit'
 include_recipe 'zookeeper::default'
-include_recipe 'runit'
 include_recipe 'zookeeper::service'
 include_recipe 'locking_resource::default'
 


### PR DESCRIPTION
This builds upon the PR for rerun support to clean-up the code for much better `foodcritic` and `rubocop` cleanliness.