### PR TITLE
optional lock release delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Will run the requested action every Chef run as long as a lock can be acquired
 * `:perform` - Action to perform on `:resource` when called (locked resources are often set to `:nothing` to avoid running outside of lock)
 * `:timeout` - Optional timeout override for resources which might hold a lock particularly long
 * `:lock_data` - Optional data to put in lock; (envisioned to provide ability to lock on a topology grouping e.g. a rack)
+* `:release_delay` - Optional value to indicate that the resource should sleep for a number of seconds after converging a wrapped resource (default: 0)
 
 #### `:serialize_process`
 Will run the requested action every Chef run as long as a lock can be acquired; provides extra features for a process affecting resource. Will verify that if the machine is found to be holding a stale lock and the process as restarted since the lock was taken out, the lock will be released with no action. This provides an ability for a service to fail restarting (e.g. due to an exogenous resource failure; like a disk), to take out a lock to prevent other like processes going down electively and to be cleared by an administrator (e.g. disk replaced) and for Chef to clear the condition automatically.

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -180,7 +180,7 @@ module LockingResource
     # Raises: If the node does not provide correct data
     #         (and does not remove lock)
     #
-    def release_lock(quorum_hosts, path, data)
+    def release_lock(quorum_hosts, path, data, delay)
       run_zk_block(quorum_hosts) do |zk|
         if lock_matches?(quorum_hosts, path, data)
           ret = zk.delete(path: path)
@@ -189,6 +189,7 @@ module LockingResource
                 'release_lock: node does not contain expected data ' \
                 'not releasing the lock'
         end
+        sleep delay
         true if ret[:rc].zero?
       end ? true : false # ensure we catch returning nil and make it false
     end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -183,13 +183,13 @@ module LockingResource
     def release_lock(quorum_hosts, path, data, delay)
       run_zk_block(quorum_hosts) do |zk|
         if lock_matches?(quorum_hosts, path, data)
+          sleep delay
           ret = zk.delete(path: path)
         else
           raise ::LockingResource::Helper::LockingResourceException,
                 'release_lock: node does not contain expected data ' \
                 'not releasing the lock'
         end
-        sleep delay
         true if ret[:rc].zero?
       end ? true : false # ensure we catch returning nil and make it false
     end

--- a/libraries/locking_resource.rb
+++ b/libraries/locking_resource.rb
@@ -113,7 +113,7 @@ class Chef
             new_resource.updated_by_last_action(r.updated)
             begin
               release_lock(zk_hosts, lock_path,
-                           new_resource.lock_data, release_delay)
+                           new_resource.lock_data, new_resource.release_delay)
             rescue ::LockingResource::Helper::LockingResourceException => e
               Chef::Log.warn e.message
             end
@@ -199,7 +199,7 @@ class Chef
         begin
           # release_lock will not matter if we are not holding the lock
           release_lock(zk_hosts, lock_path,
-                       new_resource.lock_data, release_delay)
+                       new_resource.lock_data, new_resource.release_delay)
         rescue ::LockingResource::Helper::LockingResourceException => e
           Chef::Log.warn e.message
         end

--- a/spec/unit/helper_spec.rb
+++ b/spec/unit/helper_spec.rb
@@ -154,7 +154,7 @@ describe LockingResource::Helper do
         expect(dbl).to receive(:closed?).exactly(1).times { false }
         expect(dbl).to receive(:close).exactly(1).times
         expect(dummy_class.release_lock(hosts, node_path,
-                                        my_data)).to match(true)
+                                        my_data, 0)).to match(true)
       end
 
       it 'returns false if lock does not match' do
@@ -167,7 +167,7 @@ describe LockingResource::Helper do
         expect do
           dummy_class.release_lock(hosts,
                                    node_path,
-                                   my_data)
+                                   my_data, 0)
         end.to raise_error(exception_str)
       end
     end
@@ -335,7 +335,7 @@ describe LockingResource::Helper do
           .and_raise(exception_str)
         expect(Chef::Log).to receive(:warn).with(exception_str)
         expect(dummy_class.release_lock(hosts, node_path,
-          my_data)).to match(true)
+          my_data, 0)).to match(true)
       end
     end
   end

--- a/test/cookbooks/locking_resource_test/recipes/lock_release_delay.rb
+++ b/test/cookbooks/locking_resource_test/recipes/lock_release_delay.rb
@@ -1,0 +1,34 @@
+include_recipe 'zookeeper::default'
+include_recipe 'zookeeper::service'
+include_recipe 'locking_resource::default'
+
+lock_resource = 'my resource'
+node.run_state['ran_action'] = false
+
+ruby_block lock_resource do
+  block do
+    Chef::Log.warn 'Dummy resource -- which should run'
+    node.run_state['ran_action'] = true
+    node.run_state['start_time'] = Time.new.to_i
+  end
+  action :nothing
+end
+
+locking_resource 'Test we run if process dead' do
+  resource "ruby_block[#{lock_resource}]"
+  process_pattern do
+    command_string 'not a command'
+  end
+  action :serialize_process
+  release_delay 5
+  perform :run
+end
+
+# Make sure we actually logged
+ruby_block 'verify dummy resource actually ran' do
+  block do
+    # verify the Chef ran the action
+    raise("Chef was supposed to run ruby_block[#{lock_resource}]") unless
+    node.run_state['ran_action'] and Time.new.to_i - node.run_state['start_time'] >= 5
+  end
+end


### PR DESCRIPTION
It is desirable to sometime not release a lock for a service that does not become available after a restart.  For example the HDFS NamenNode, restarts in seconds, but depending on the size of the fsimage or the number of outstanding DataNode Block reports my take a long time to load/exit safe mode.