### PR TITLE
Workaround evertrue/zookeeper-cookbook#218

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,6 +9,10 @@ platforms:
   - name: ubuntu-14.04
     run_list:
     attributes: {
+      zookeeper: {
+        version: "3.4.14",
+        checksum: "b14f7a0fece8bd34c7fffa46039e563ac5367607c612517aa7bd37306afbd1cd"
+      },
       locking_resource: {
         restart_lock_acquire: {
           timeout: 3

--- a/test/cookbooks/locking_resource_test/metadata.rb
+++ b/test/cookbooks/locking_resource_test/metadata.rb
@@ -6,5 +6,5 @@ description      'Installs and configures locking_resource cookbook for testing'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.0'
 
-depends 'zookeeper', '>= 8.1.4'
+depends 'zookeeper'
 depends 'locking_resource'


### PR DESCRIPTION
This works around evertrue/zookeeper-cookbook#218 to allow kitchen tests to again run.